### PR TITLE
Highlighting and scrolling to selected tracks

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "vue": "^2.6.10",
     "vue-router": "^3.0.3",
     "vue-utilities": "git+https://github.com/Kitware/vue-utilities.git#5c261826458d73c4e8c8feea1d0037c08e633582",
-    "vue-virtual-scroll-list": "^1.4.2",
+    "vue-virtual-scroll-list": "1.4.1",
     "vuetify": "^2.1.9",
     "vuex": "^3.0.1"
   },

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -103,6 +103,7 @@ export default {
 
 .selected {
   font-weight: bold;
+  background-color: var(--v-primary-darken2);
 }
 
 .hover-show-parent {

--- a/client/src/components/Tracks.vue
+++ b/client/src/components/Tracks.vue
@@ -38,6 +38,11 @@ export default {
       this.$emit("update:checkedTracks", value);
     }
   },
+  computed: {
+    selectedOffset() {
+      return this.tracks.map(item => item.trackId).indexOf(this.selectedTrack);
+    }
+  },
   methods: {
     getItemProps(itemIndex) {
       var track = this.tracks[itemIndex];
@@ -90,6 +95,7 @@ export default {
     <virtual-list
       :size="45"
       :remain="9"
+      :start="selectedOffset"
       :item="item"
       :itemcount="tracks.length"
       :itemprops="getItemProps"

--- a/client/src/plugins/vuetify.js
+++ b/client/src/plugins/vuetify.js
@@ -6,7 +6,7 @@ import vuetifyConfig from "@girder/components/src/utils/vuetifyConfig.js";
 import "@mdi/font/css/materialdesignicons.css";
 
 Vue.use(Vuetify);
-
+vuetifyConfig.theme.options.customProperties = true;
 vuetifyConfig.theme.dark = true;
 vuetifyConfig.theme.themes.dark = {
   ...vuetifyConfig.theme.themes.dark,


### PR DESCRIPTION
- **package.json**  - Downgrade of the vue-virtual-scroll-list to fix a bug in which it was continually calling getItemProps and rendering the list even with no actual changes. see [vue-virtual-scroll-list issue 146](https://github.com/tangbc/vue-virtual-scroll-list/issues/146).
- **Vuetify.config edit** - Enabled the custom properties to directly access theme colors/styling as css vars, to ensure that highlighting matches the current theme.
- **selectedOffset computed property** to figure out the offset in virtual list to scroll to.  This is where things might need to change in the future.  Doing a map and indexOf each time you change the selection could be costly on extremely long lists of tracks.  It might make sense to create a HashMap of the track list with the key being the ID and the value being the index location in the list.  Then update that when changes to the list occur (additional/deletions/insertions).  Obviously this only makes sense on extremely large track lists (1000+).  Also I wouldn't want this data to be available just to the Tracks component.  
