### PR TITLE
[feature] allow independent head and tail track annotations

### DIFF
--- a/client/src/components/AnnotationLayer.vue
+++ b/client/src/components/AnnotationLayer.vue
@@ -62,8 +62,6 @@ export default {
     }
   },
   mounted() {
-    // console.log('mounted');
-    // console.log(this.annotator.viewer);
     var viewer = this.annotator.viewer;
     this.featureLayer = viewer.createLayer("feature", {
       features: ["point", "line", "polygon"]

--- a/client/src/components/AttributeInput.vue
+++ b/client/src/components/AttributeInput.vue
@@ -34,7 +34,6 @@ export default {
           value = undefined;
           break;
       }
-      console.log(value);
       this.$emit("change", { name: this.name, value });
     }
   }

--- a/client/src/components/EditAnnotationLayer.vue
+++ b/client/src/components/EditAnnotationLayer.vue
@@ -38,9 +38,11 @@ export default {
   },
   watch: {
     geojson() {
+      // reinitialize when annotations change.
       this.reinitialize();
     },
     editing() {
+      // reinitialize when pointer editing mode is toggled
       this.reinitialize();
     }
   },

--- a/client/src/components/ImageAnnotator.vue
+++ b/client/src/components/ImageAnnotator.vue
@@ -106,7 +106,7 @@ export default {
         this.playing = true;
         this.syncWithVideo();
       } catch (ex) {
-        console.log(ex);
+        console.error(ex);
       }
     },
     async seek(frame) {
@@ -163,9 +163,7 @@ export default {
         setTimeout(this.syncWithVideo, 1000 / this.frameRate);
       }
     },
-    rendered() {
-      // console.log("rendered an");
-    },
+    rendered() {},
     cacheImage() {
       var frame = this.frame;
       var max = Math.min(frame + 10, this.maxFrame);

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -144,7 +144,7 @@ async function readEntriesPromise(directoryReader) {
       directoryReader.readEntries(resolve, reject);
     });
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 }
 

--- a/client/src/components/VideoAnnotator.vue
+++ b/client/src/components/VideoAnnotator.vue
@@ -115,7 +115,7 @@ export default {
         this.playing = true;
         this.syncWithVideo();
       } catch (ex) {
-        console.log(ex);
+        console.error(ex);
       }
     },
     async seek(frame) {
@@ -146,7 +146,6 @@ export default {
     },
     videoPaused() {
       if (this.video.currentTime === this.video.duration) {
-        // console.log("video ended");
         this.frame = 0;
         this.syncedFrame = 0;
         this.pause();
@@ -172,9 +171,7 @@ export default {
     emitFrame() {
       this.$emit("frame-update", this.frame);
     },
-    rendered() {
-      // console.log("rendered an");
-    }
+    rendered() {}
   }
 };
 </script>

--- a/client/src/components/VideoAnnotator.vue
+++ b/client/src/components/VideoAnnotator.vue
@@ -64,9 +64,6 @@ export default {
       this.init();
     };
     video.addEventListener("pause", this.videoPaused);
-    // setTimeout(() => {
-    //   this.play();
-    // }, 2000);
   },
   methods: {
     init() {

--- a/client/src/components/timeline/LineChart.vue
+++ b/client/src/components/timeline/LineChart.vue
@@ -167,9 +167,7 @@ export default {
       });
       this.path.attr("d", d => this.line(d.values));
     },
-    rendered() {
-      console.log("linechart rendered");
-    }
+    rendered() {}
   }
 };
 </script>

--- a/client/src/components/timeline/Timeline.vue
+++ b/client/src/components/timeline/Timeline.vue
@@ -187,9 +187,6 @@ export default {
     containerMouseup() {
       this.minimapDragging = false;
     }
-    // rendered() {
-    // console.log("timeline rendered");
-    // }
   }
 };
 </script>

--- a/client/src/views/Viewer.vue
+++ b/client/src/views/Viewer.vue
@@ -861,15 +861,20 @@ function geojsonToBound2(geojson) {
             </v-btn>
           </template>
           <v-list>
-            <v-list-item @click="toggleFeaturePointing">
-              <v-list-item-title>Add feature points (F key)</v-list-item-title>
+            <v-list-item @click="toggleFeaturePointing('head')">
+              <v-list-item-title>
+                Add feauture points, starting with head (g key)
+              </v-list-item-title>
             </v-list-item>
-            <v-list-item @click="deleteFeaturePoints">
-              <v-list-item-title>Delete feature points</v-list-item-title>
+            <v-list-item @click="toggleFeaturePointing('tail')">
+              <v-list-item-title>
+                Add feature points, starting with tail (t key)
+              </v-list-item-title>
             </v-list-item>
-            <v-divider />
             <v-list-item @click="deleteDetection">
-              <v-list-item-title>Delete detection (D key)</v-list-item-title>
+              <v-list-item-title>
+                Delete both feauture points for current frame (q key)
+              </v-list-item-title>
             </v-list-item>
           </v-list>
         </v-menu>

--- a/client/src/views/Viewer.vue
+++ b/client/src/views/Viewer.vue
@@ -70,7 +70,7 @@ export default {
     frame: null,
     pendingSave: false,
     featurePointing: false,
-    featurePointIndex: 0,
+    featurePointTarget: "head",
     featurePointingGeojson: null
   }),
   computed: {
@@ -398,6 +398,17 @@ export default {
   methods: {
     typeColorMap,
     getPathFromLocation,
+    /* TODO: DANGER: reaching into refs like this is highly non-standard */
+    seek(frame) {
+      this.$refs.playbackComponent.provided.$emit("seek", frame);
+    },
+    nextFrame() {
+      this.$refs.playbackComponent.provided.$emit("next-frame");
+    },
+    prevFrame() {
+      this.$refs.playbackComponent.provided.$emit("next-frame");
+    },
+    /* END TODO */
     async loadDataset(datasetId) {
       var { data: dataset } = await this.girderRest.get(`folder/${datasetId}`);
       if (!dataset || !dataset.meta || !dataset.meta.viame) {
@@ -439,7 +450,7 @@ export default {
       this.selectedTrackId = track.trackId;
       var frame = this.eventChartData.find(d => d.track === track.trackId)
         .range[0];
-      this.$refs.playpackComponent.provided.$emit("seek", frame);
+      this.seek(frame);
     },
     async deleteTrack(track) {
       var result = await this.$prompt({
@@ -466,46 +477,60 @@ export default {
     addTrack() {
       this.editingTrack = this.tracks.slice(-1)[0].trackId + 1;
     },
-    toggleFeaturePointing() {
+    async toggleFeaturePointing(target) {
+      this.editingTrack = null;
+      await this.$nextTick();
+      this.featurePointingTarget = target;
       if (this.featurePointing) {
         this.featurePointing = false;
-        this.featurePointIndex = 0;
       } else if (this.selectedTrackId === null) {
         return;
       } else {
         this.featurePointing = true;
       }
     },
+    /**
+     * When a feature point is set, update the selected detection.
+     * - if both head and tail are set, we're done.
+     * - if only one is set, automatically prepare to collect the other.
+     * - when both are set, or when right click or escape are hit, disable feature pointing.
+     */
     featurePointed(geojson) {
       this.pendingSave = true;
       var [x, y] = geojson.geometry.coordinates;
       var selectedDetection = this.selectedDetection;
       this.detections.splice(this.detections.indexOf(selectedDetection), 1);
-      this.detections.push(
-        Object.freeze({
-          ...selectedDetection,
-          ...{
-            features: {
-              ...selectedDetection.features,
-              ...{
-                [["head", "tail"][this.featurePointIndex]]: [
-                  x.toFixed(0),
-                  y.toFixed(0)
-                ]
-              }
-            }
+      const newDetection = Object.freeze({
+        ...selectedDetection,
+        ...{
+          features: {
+            ...selectedDetection.features,
+            [this.featurePointingTarget]: [x.toFixed(0), y.toFixed(0)]
           }
-        })
-      );
-      this.featurePointing = false;
-      this.$nextTick(() => {
-        if (this.featurePointIndex < 1) {
-          this.featurePointIndex++;
-          this.featurePointing = true;
-        } else {
-          this.featurePointIndex = 0;
         }
       });
+      this.detections.push(newDetection);
+      /* TODO: DANGER: this is highly non-standard
+       * this and the nextTick() are here to cause
+       * the initialization function inside the EditAnnotationLayer to trip
+       */
+      this.featurePointing = false;
+      this.$nextTick(() => {
+        if (this.featurePointingTarget === "tail") {
+          this.featurePointingTarget = "head";
+        } else {
+          this.featurePointingTarget = "tail";
+        }
+        if (
+          "head" in newDetection.features &&
+          "tail" in newDetection.features
+        ) {
+          this.featurePointing = false;
+        } else {
+          this.featurePointing = true;
+        }
+      });
+      /* END TODO */
     },
     deleteFeaturePoints() {
       this.pendingSave = true;
@@ -752,7 +777,7 @@ function geojsonToBound2(geojson) {
       <v-col style="position: relative; ">
         <component
           class="playback-component"
-          ref="playpackComponent"
+          ref="playbackComponent"
           v-if="imageUrls || videoUrl"
           :is="annotatorType"
           :image-urls="imageUrls"
@@ -760,8 +785,13 @@ function geojsonToBound2(geojson) {
           :frame-rate="frameRate"
           @frame-update="frame = $event"
           v-mousetrap="[
-            { bind: 'f', handler: toggleFeaturePointing },
-            { bind: 'd', handler: deleteDetection }
+            { bind: 'g', handler: () => toggleFeaturePointing('head') },
+            { bind: 'h', handler: () => toggleFeaturePointing('head') },
+            { bind: 't', handler: () => toggleFeaturePointing('tail') },
+            { bind: 'y', handler: () => toggleFeaturePointing('tail') },
+            { bind: 'f', handler: () => $refs.playbackComponent.nextFrame() },
+            { bind: 'd', handler: () => $refs.playbackComponent.prevFrame() },
+            { bind: 'q', handler: deleteDetection }
           ]"
         >
           <template slot="control">


### PR DESCRIPTION
Adds ability to annotation head and tail independently

* removes `f` and `d` keybindings for annotation
* adds `g` and `h` keybindings for head annotation (right and left handed)
* adds `t` and `y` keybindings for tail annotation (...)
* adds `f` and `d` keybindings for +1 frame and -1 frame (standard video interface UI/UX)
* adds `q` for delete head/tail annotations.

Press g, h, t, or y to start an annotation.  
* if neither exists, you will be prompted to provide both, starting with the key you pressed.
* if you don't want to provide both, tap any of the keys to exit the edit state.
* if both (or one) already exists, you will only be prompted to provide the one corresponding to the key you pressed

PR also cleans up some `console.log` lines and adds comments denoting code quality issues.
Adding line will be done in a follow-up PR.

fixes #10