### PR TITLE
[enhancement] upload progress fixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@girder/components": "git+https://github.com/girder/girder_web_components.git#415bda55ea66ea6538af324217c06508b7431d40",
+    "@girder/components": "git+https://github.com/girder/girder_web_components.git",
     "core-js": "^2.6.5",
     "d3": "^5.12.0",
     "geojs": "^0.19.5",

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -39,20 +39,22 @@ export default {
         item => item.status !== "done" && item.status !== "error"
       ).length;
     },
-    // Takes the pending upload and returns the # of images or size of the file
+    /**
+     * Takes the pending upload and returns the # of images or size of the file based on the type and state
+     * @param {Object} pendingUpload - contains , status, type
+     *  size, and list of files to upload.
+     */
     computeUploadProgress(pendingUpload) {
-      // formatSize, totalProgress and totalSize are located in the fileUploader and sizeFormatter mixin
+      const { formatSize, totalProgress, totalSize } = this; // use methods and properties from mixins
       if (pendingUpload.files.length === 1 && !pendingUpload.uploading) {
         return this.formatSize(pendingUpload.files[0].progress.size);
-      } else if (pendingUpload.type == "image-sequence") {
+      } else if (pendingUpload.type === "image-sequence") {
         return `${this.filesNotUploaded(pendingUpload)} images`;
-      } else if (pendingUpload.type == "video" && !pendingUpload.uploading) {
+      } else if (pendingUpload.type === "video" && !pendingUpload.uploading) {
         return `${this.filesNotUploaded(pendingUpload)} videos`;
       } else if (pendingUpload.type === "video" && pendingUpload.uploading) {
         // For videos we display the total progress when uploading because single videos can be large
-        return `${this.formatSize(this.totalProgress)} of ${this.formatSize(
-          this.totalSize
-        )}`;
+        return `${formatSize(totalProgress)} of ${formatSize(totalSize)}`;
       }
     },
     async dropped(e) {
@@ -107,7 +109,6 @@ export default {
         await this.uploadPending(this.pendingUploads[0], uploaded);
       }
       this.$emit("update:uploading", false);
-      console.log(uploaded);
       this.$emit("uploaded", uploaded);
     },
     async uploadPending(pendingUpload, uploaded) {
@@ -161,7 +162,7 @@ export default {
         // Upload Mixin function to start uploading
         await this.start({
           dest: folder,
-          postUpload: postUpload
+          postUpload
         });
         this.remove(pendingUpload);
       }

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -112,11 +112,12 @@ export default {
       this.$emit("uploaded", uploaded);
     },
     async uploadPending(pendingUpload, uploaded) {
-      var { name, files, fps } = pendingUpload;
+      let { name, files, fps } = pendingUpload;
       fps = parseInt(fps);
       pendingUpload.uploading = true;
-      var { data: folder } = await this.girderRest
-        .post(
+      let folder;
+      try {
+        ({ data: folder } = await this.girderRest.post(
           "/folder",
           `metadata=${JSON.stringify({
             viame: true,
@@ -129,27 +130,27 @@ export default {
               name
             }
           }
-        )
-        .catch(error => {
-          if (
-            error.response &&
-            error.response.data &&
-            error.response.data.message
-          ) {
-            this.errorMessage = error.response.data.message;
-          } else {
-            this.errorMessage = error;
-          }
-          pendingUpload.uploading = false;
-          // Return empty object for the folder destructuring
-          return { data: null };
-        });
+        ));
+      } catch (error) {
+        if (
+          error.response &&
+          error.response.data &&
+          error.response.data.message
+        ) {
+          this.errorMessage = error.response.data.message;
+        } else {
+          this.errorMessage = error;
+        }
+        pendingUpload.uploading = false;
+        // Set an empty object for the folder destructuring
+        folder = null;
+      }
 
       // function called after mixins upload finishes
       const postUpload = data => {
         uploaded.push({
           folder,
-          results: data.results,
+          results: data && data.results,
           pipeline: pendingUpload.pipeline
         });
       };

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -40,7 +40,6 @@ export default {
       ).length;
     },
     /**
-     * Takes the pending upload and returns the # of images or size of the file based on the type and state
      * @param {{ type: string, size: number, files: Array, uploading: boolean }} pendingUpload
      * @returns {number} # of images or size of file depending on type and state
      *  size, and list of files to upload.

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -1,7 +1,6 @@
 <script>
 import { mapState } from "vuex";
 import Dropzone from "@girder/components/src/components/Presentation/Dropzone.vue";
-import { Upload } from "@girder/components/src/utils";
 import {
   fileUploader,
   sizeFormatter
@@ -51,7 +50,7 @@ export default {
     addPendingUpload(name, allFiles) {
       var [type, files] = prepareFiles(allFiles);
       let defaultFilename = files[0].name;
-      // mapping needs to be done for the mixin upload tool
+      // mapping needs to be done for the mixin upload functions
       files = files.map(file => ({
         file,
         status: "pending",
@@ -91,6 +90,7 @@ export default {
         await this.uploadPending(this.pendingUploads[0], uploaded);
       }
       this.$emit("update:uploading", false);
+      console.log(uploaded);
       this.$emit("uploaded", uploaded);
     },
     async uploadPending(pendingUpload, uploaded) {
@@ -113,10 +113,10 @@ export default {
       );
 
       // function called after mixins upload finishes
-      const postUpload = result => {
+      const postUpload = data => {
         uploaded.push({
           folder,
-          result,
+          results: data.results,
           pipeline: pendingUpload.pipeline
         });
       };

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -2,17 +2,16 @@
 import { mapState } from "vuex";
 import Dropzone from "@girder/components/src/components/Presentation/Dropzone.vue";
 import { Upload } from "@girder/components/src/utils";
+import { fileUploader } from "@girder/components/src/utils/mixins";
 
 export default {
   name: "Upload",
   components: { Dropzone },
+  mixins: [fileUploader],
   inject: ["girderRest"],
   props: {
     location: {
       type: Object
-    },
-    uploading: {
-      type: Boolean
     }
   },
   data: () => ({
@@ -83,6 +82,8 @@ export default {
               }
             }
           );
+          await this.start(folder);
+          /*
           var pending = files;
           var results = [];
           while (pending.length) {
@@ -98,6 +99,7 @@ export default {
               )
             );
           }
+          */
           uploaded.push({ folder, results, pipeline: pendingUpload.pipeline });
           this.remove(pendingUpload);
         })
@@ -232,7 +234,7 @@ function prepareFiles(files) {
             <v-list-item-subtitle
               v-if="pendingUpload.type === 'image-sequence'"
             >
-              {{ pendingUpload.files.length }} images
+              {{ totalProgress }} images
             </v-list-item-subtitle>
           </v-list-item-content>
           <v-list-item-action>

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -41,7 +41,8 @@ export default {
     },
     /**
      * Takes the pending upload and returns the # of images or size of the file based on the type and state
-     * @param {Object} pendingUpload - contains , status, type
+     * @param {{ type: string, size: number, files: Array, uploading: boolean }} pendingUpload
+     * @returns {number} # of images or size of file depending on type and state
      *  size, and list of files to upload.
      */
     computeUploadProgress(pendingUpload) {


### PR DESCRIPTION
Changes

- Added default FPS to 10 when uploading files
- Added in default upload Folder name, based on the first file in the list and removing the extension
- Changed 'Upload' to 'Start Upload', multiple times I got confused and clicked 'Upload' thinking it would allow me to add more files
- Implemented the fileUploader mixin from Girder Web Components
- Image counter now decreases as the images are uploading.  That was the original intention of how this component was designed, it didn't work properly because of the batch uploading (instantly tried uploading 500 items).
- If the upload is a single file, it will display the file size
- If the upload is a list of videos it will display the number, then when it starts uploading it will display the current amount of data uploaded and the total aggregate size of the videos
- Restructured the uploading process to allow adding additional items while uploading.  (Let me know if we want something better than a while->await loop for this)
- Added in some error message handling based on GWC.  Standard mixing error handling plus handling response errors when creating the folder to uploading items to.
- ![image](https://user-images.githubusercontent.com/61746913/77646680-6404a100-6f3b-11ea-8a2b-e5be4316b5b1.png)
- ![image](https://user-images.githubusercontent.com/61746913/77646692-6830be80-6f3b-11ea-91b0-f79203ab7427.png)

