### PR TITLE
Changing Default Styling

### DIFF
--- a/client/src/components/AnnotationLayer.vue
+++ b/client/src/components/AnnotationLayer.vue
@@ -91,7 +91,7 @@ export default {
         ...{
           stroke: true,
           uniformPolygon: true,
-          strokeColor: "lime",
+          strokeColor: this.$vuetify.theme.themes.dark.accent,
           strokeWidth: 1,
           fill: false
         },

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -103,7 +103,7 @@ export default {
 
 .selected {
   font-weight: bold;
-  background-color: var(--v-primary-darken2);
+  background-color: var(--v-accent-darken2);
 }
 
 .hover-show-parent {

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -103,7 +103,7 @@ export default {
 
 .selected {
   font-weight: bold;
-  background-color: var(--v-accent-darken2);
+  background-color: var(--v-accent-base);
 }
 
 .hover-show-parent {

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -309,7 +309,7 @@ function prepareFiles(files) {
                   </v-btn>
                 </v-alert>
               </div>
-            </v-list-item-subtitle>
+            </v-list-item-subtitle>            
           </v-list-item-content>
           <v-list-item-action>
             <v-btn

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -309,7 +309,7 @@ function prepareFiles(files) {
                   </v-btn>
                 </v-alert>
               </div>
-            </v-list-item-subtitle>            
+            </v-list-item-subtitle>
           </v-list-item-content>
           <v-list-item-action>
             <v-btn

--- a/client/src/components/timeline/EventChart.vue
+++ b/client/src/components/timeline/EventChart.vue
@@ -85,6 +85,7 @@ export default {
                 width: Math.max(x(event.range[1]) - left, 3),
                 top: i * 15,
                 color: event.color,
+                selected: event.selected,
                 name: event.name
               });
             });
@@ -135,8 +136,22 @@ export default {
       canvas.width = this.$el.clientWidth;
       canvas.height = bars.slice(-1)[0].top + 10;
       for (var bar of bars) {
+        let padding = 0;
+        console.log(bar);
+        if (bar.selected) {
+          ctx.fillStyle = this.$vuetify.theme.themes.dark.accent;
+
+          ctx.fillRect(bar.left, bar.top, bar.width, 10);
+          padding = 2;
+        }
+
         ctx.fillStyle = bar.color ? bar.color : "#4c9ac2";
-        ctx.fillRect(bar.left, bar.top, bar.width, 10);
+        ctx.fillRect(
+          bar.left + padding,
+          bar.top + padding,
+          bar.width - padding*2,
+          10 - padding*2
+        );
       }
     },
     mousemove(e) {

--- a/client/src/components/timeline/EventChart.vue
+++ b/client/src/components/timeline/EventChart.vue
@@ -137,7 +137,6 @@ export default {
       canvas.height = bars.slice(-1)[0].top + 10;
       for (var bar of bars) {
         let padding = 0;
-        console.log(bar);
         if (bar.selected) {
           ctx.fillStyle = this.$vuetify.theme.themes.dark.accent;
 

--- a/client/src/plugins/vuetify.js
+++ b/client/src/plugins/vuetify.js
@@ -10,7 +10,8 @@ vuetifyConfig.theme.options.customProperties = true;
 vuetifyConfig.theme.dark = true;
 vuetifyConfig.theme.themes.dark = {
   ...vuetifyConfig.theme.themes.dark,
-  ...{ accent: colors.blue.lighten1, primary: { base: "#004787" } }
+  ...{ accent: colors.blue.lighten1 },
+  ...{ primary: "#004787" }
 };
 
 export default new Vuetify(vuetifyConfig);

--- a/client/src/plugins/vuetify.js
+++ b/client/src/plugins/vuetify.js
@@ -10,7 +10,7 @@ vuetifyConfig.theme.options.customProperties = true;
 vuetifyConfig.theme.dark = true;
 vuetifyConfig.theme.themes.dark = {
   ...vuetifyConfig.theme.themes.dark,
-  ...{ accent: colors.blue.lighten3 }
+  ...{ accent: colors.blue.lighten1, primary: { base: "#004787" } }
 };
 
 export default new Vuetify(vuetifyConfig);

--- a/client/src/plugins/vuetify.js
+++ b/client/src/plugins/vuetify.js
@@ -10,8 +10,8 @@ vuetifyConfig.theme.options.customProperties = true;
 vuetifyConfig.theme.dark = true;
 vuetifyConfig.theme.themes.dark = {
   ...vuetifyConfig.theme.themes.dark,
-  ...{ accent: colors.blue.lighten1 },
-  ...{ primary: "#004787" }
+  accent: colors.blue.lighten1,
+  primary: "#004787"
 };
 
 export default new Vuetify(vuetifyConfig);

--- a/client/src/views/Viewer.vue
+++ b/client/src/views/Viewer.vue
@@ -151,6 +151,9 @@ export default {
         },
         strokeOpacity: (a, b, data) => {
           return data.record.detection.track === editingTrack ? 0.5 : 1;
+        },
+        strokeWidth: (a, b, data) => {
+          return data.record.detection.track === selectedTrackId ? 4 : 1;
         }
       };
     },

--- a/client/src/views/Viewer.vue
+++ b/client/src/views/Viewer.vue
@@ -23,15 +23,14 @@ import EventChart from "@/components/timeline/EventChart";
 import { getPathFromLocation } from "@/utils";
 
 var typeColors = [
-  colors.red.accent2,
-  "aqua",
-  "fuchsia",
-  "yellow",
-  colors.purple.lighten2,
-  "#0099FF",
-  colors.amber.accent3,
-  colors.green.accent2,
-  colors.lightBlue.accent2
+  colors.red.accent1,
+  colors.pink.accent1,
+  colors.yellow.darken3,
+  colors.purple.lighten3,
+  colors.green.lighten3,
+  colors.yellow.lighten3,
+  colors.purple.darken3,
+  colors.green.darken3
 ];
 var typeColorMap = d3.scaleOrdinal();
 typeColorMap.range(typeColors);
@@ -143,7 +142,7 @@ export default {
       return {
         strokeColor: (a, b, data) => {
           if (data.record.detection.track === selectedTrackId) {
-            return "lime";
+            return this.$vuetify.theme.themes.dark.accent;
           }
           if (data.record.detection.confidencePairs.length) {
             return typeColorMap(data.record.detection.confidencePairs[0][0]);
@@ -186,7 +185,7 @@ export default {
       return {
         color: data => {
           if (data.detection.track === selectedTrackId) {
-            return "lime";
+            return this.$vuetify.theme.themes.dark.accent;
           }
           return typeColorMap(data.detection.confidencePairs[0][0]);
         },
@@ -221,7 +220,7 @@ export default {
         },
         radius: 4,
         stroke: data => data.detection.track === selectedTrackId,
-        strokeColor: "lime"
+        strokeColor: this.$vuetify.theme.themes.dark.accent
       };
     },
     lineChartData() {
@@ -839,7 +838,7 @@ function geojsonToBound2(geojson) {
             v-if="editingTrack !== null"
             editing="rectangle"
             :geojson="editingDetectionGeojson"
-            :feature-style="{ fill: false, strokeColor: 'lime' }"
+            :feature-style="{ fill: false, strokeColor: this.$vuetify.theme.themes.dark.accent }"
             @update:geojson="detectionChanged"
           />
           <EditAnnotationLayer

--- a/client/src/views/Viewer.vue
+++ b/client/src/views/Viewer.vue
@@ -24,7 +24,6 @@ import { getPathFromLocation } from "@/utils";
 
 var typeColors = [
   colors.red.accent1,
-  colors.pink.accent1,
   colors.yellow.darken3,
   colors.purple.lighten3,
   colors.green.lighten3,
@@ -275,6 +274,7 @@ export default {
             track: detections[0].track,
             name: `Track ${name}`,
             color: typeColorMap(detections[0].confidencePairs[0][0]),
+            selected: detections[0].track === this.selectedTrackId,
             range
           };
         });

--- a/client/src/views/Viewer.vue
+++ b/client/src/views/Viewer.vue
@@ -838,7 +838,10 @@ function geojsonToBound2(geojson) {
             v-if="editingTrack !== null"
             editing="rectangle"
             :geojson="editingDetectionGeojson"
-            :feature-style="{ fill: false, strokeColor: this.$vuetify.theme.themes.dark.accent }"
+            :feature-style="{
+              fill: false,
+              strokeColor: this.$vuetify.theme.themes.dark.accent
+            }"
             @update:geojson="detectionChanged"
           />
           <EditAnnotationLayer


### PR DESCRIPTION
When other PRs are done I'll rebase to the latest:

- Changed default styling to use some more muted blue colors for the accent and base primary color.  This is mainly seen in the login screen and some of the highlights in the system.
Old Color: 
![image](https://user-images.githubusercontent.com/61746913/78024521-807f4f80-7326-11ea-9c99-8dfdd2934e57.png)
New Color:
![image](https://user-images.githubusercontent.com/61746913/78024534-86753080-7326-11ea-8dbe-e098dfd351b9.png)
- Modified the default colors for types to be a list of Vuetify colors that had been slightly desaturated.  To much muting makes it harder to tell the difference between them.  
- Swapped the 'lime' highlight to using the vuetify accent color.  This is consistent with the highlighting of the track item in the list.  Makes it consistent that a highlighted or selected item in VIAME-Web utilizes the Vuetify accent color to indicate that it is selected.
- To indicate a highlighted track I added a selected (boolean) properly to the eventChartData sent to the event chart.  If it is currently selected it will place a small accent color border around the track in the event chart.  Only issue with this is a one frame annotation (doesn't have enough space for a border).  I didn't want to use desaturated and saturated colors because I don't want the colors of the types to not be clear.

![image](https://user-images.githubusercontent.com/61746913/78024499-75c4ba80-7326-11ea-9847-21c3fbf1eefd.png)
