### PR TITLE
Create folder option

### DIFF
--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -272,12 +272,7 @@ function prepareFiles(files) {
                   ]"
                   required
                   :label="
-                    (pendingUpload.createFolder ? 'Folder' : 'File') +
-                      ' Name' +
-                      (!pendingUpload.createFolder &&
-                      pendingUpload.files.length > 1
-                        ? 's'
-                        : '')
+                    (pendingUpload.createFolder ? 'Folder' : 'File') + ' Name'
                   "
                   :disabled="
                     pendingUpload.uploading ||

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -294,13 +294,7 @@ function prepareFiles(files) {
                 ></v-text-field>
               </v-col>
 
-              <v-col
-                cols="2"
-                v-if="
-                  pendingUpload.type === 'image-sequence' &&
-                    pendingUpload.createFolder
-                "
-              >
+              <v-col cols="2" v-if="pendingUpload.createFolder">
                 <v-text-field
                   v-model="pendingUpload.fps"
                   type="number"
@@ -312,14 +306,6 @@ function prepareFiles(files) {
                   hide-details
                   :disabled="pendingUpload.uploading"
                 ></v-text-field>
-              </v-col>
-              <v-col cols="4">
-                <v-select
-                  v-model="pendingUpload.pipeline"
-                  :items="pipelineItems"
-                  label="Run pipeline"
-                  :disabled="pendingUpload.uploading"
-                />
               </v-col>
               <v-col cols="1">
                 <v-list-item-action>

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -152,18 +152,14 @@ export default {
         }
       }
 
-      // If the filename is different from the uploaded file
+      // If a single file's chosen filename is different from the uploaded file
       if (
-        files.length === 1 &&
         !createFolder &&
+        files.length === 1 &&
         files[0].file.name !== pendingUpload.name
       ) {
-        /* TODO: Upgrade Girder Web Components upload mixin to add params
-                 this is a hacky way to rename a single file
-        */
-        files[0].file = new File([files[0].file], pendingUpload.name, {
-          type: files[0].file.type
-        });
+        // Mixin parameters for uploading to overwrite file name
+        files[0].uploadClsParams = { name: pendingUpload.name };
       }
 
       // function called after mixins upload finishes

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -49,30 +49,24 @@ export default {
         return `${formatSize(totalProgress)} of ${formatSize(totalSize)}`;
       }
     },
-    /**
-     * Calculates the field properties for each pending upload
-     * @param {('label'|'disabled'|'default')} field - the field property we want the current state for
-     * @param {{createFolder: boolean, files: Array}} pendingUpload
-     */
-    getFilenameInputState(field, pendingUpload) {
-      if (field === "label") {
-        let label = pendingUpload.createFolder ? "Folder" : "File";
-        label += " Name";
-        if (!pendingUpload.createFolder && pendingUpload.files.length > 1) {
-          label += "s";
-        }
-        return label;
-      } else if (field === "disabled") {
-        return (
-          pendingUpload.uploading ||
-          (!pendingUpload.createFolder && pendingUpload.files.length > 1)
-        );
-      } else if (field === "hint") {
-        return !pendingUpload.createFolder && pendingUpload.files.length > 1
-          ? "default filenames are used"
+    getFilenameInputStateLabel(pendingUpload) {
+      const type = pendingUpload.createFolder ? "Folder" : "File";
+      const plural =
+        !pendingUpload.createFolder && pendingUpload.files.length > 1
+          ? "s"
           : "";
-      }
-      return false;
+      return `${type} Name${plural}`;
+    },
+    getFilenameInputStateDisabled(pendingUpload) {
+      return (
+        pendingUpload.uploading ||
+        (!pendingUpload.createFolder && pendingUpload.files.length > 1)
+      );
+    },
+    getFilenameInputStateHint(pendingUpload) {
+      return !pendingUpload.createFolder && pendingUpload.files.length > 1
+        ? "default filenames are used"
+        : "";
     },
     async dropped(e) {
       e.preventDefault();
@@ -301,10 +295,10 @@ function prepareFiles(files) {
                     val => (val || '').length > 0 || 'This field is required'
                   ]"
                   required
-                  :label="getFilenameInputState('label', pendingUpload)"
-                  :disabled="getFilenameInputState('disabled', pendingUpload)"
+                  :label="getFilenameInputStateLabel(pendingUpload)"
+                  :disabled="getFilenameInputStateDisabled(pendingUpload)"
+                  :hint="getFilenameInputStateHint(pendingUpload)"
                   persistent-hint
-                  :hint="getFilenameInputState('hint', pendingUpload)"
                 ></v-text-field>
               </v-col>
 


### PR DESCRIPTION
fixes #18 and fixes #19 

Adds the ability to create a folder or to rename a single file when it is uploaded.  

- You can upload multiple files and specify the folder name
- You can upload multiple files into the current folder - then default filenames are used
- You can upload a single file and specify a new name if you want.
- 

If you choose a single file, the file name is preselected with the extension.
Foldernames default to the first filename in the list minus the extension.  I don't know if an easy way to get the parent folder from an input dialog for a collection of files.

![image](https://user-images.githubusercontent.com/61746913/78392264-f3522a00-75b5-11ea-912e-646e8e51db86.png)
