### PR TITLE
[bugfix] resolve color contrast issues

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -42,6 +42,7 @@ export default {
       dense
       hide-details
       :input-value="inputValue"
+      color="white"
       @change="$emit('change', $event)"
     >
     </v-checkbox>

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -42,7 +42,7 @@ export default {
       dense
       hide-details
       :input-value="inputValue"
-      color="white"
+      color="neutral"
       @change="$emit('change', $event)"
     >
     </v-checkbox>

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -38,7 +38,7 @@ export default {
           :key="type"
           class="my-2 ml-3"
           v-model="checkedTypes_"
-          color="white"
+          color="neutral"
           :value="type"
           dense
           hide-details

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -38,6 +38,7 @@ export default {
           :key="type"
           class="my-2 ml-3"
           v-model="checkedTypes_"
+          color="white"
           :value="type"
           dense
           hide-details

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -285,6 +285,7 @@ function prepareFiles(files) {
                 <v-checkbox
                   label="Create Folder"
                   v-model="pendingUpload.createFolder"
+                  class="pl-2"
                 />
               </v-col>
               <v-col>

--- a/client/src/plugins/vuetify.js
+++ b/client/src/plugins/vuetify.js
@@ -17,7 +17,9 @@ const appVuetifyConfig = merge(girderVuetifyConfig, {
     themes: {
       dark: {
         accent: colors.blue.lighten1,
-        primary: colors.blue.base
+        secondary: colors.grey.darken1,
+        primary: colors.blue.darken2,
+        neutral: colors.grey.lighten5
       }
     }
   }

--- a/client/src/plugins/vuetify.js
+++ b/client/src/plugins/vuetify.js
@@ -1,17 +1,26 @@
 import Vue from "vue";
 import Vuetify from "vuetify/lib";
 import colors from "vuetify/lib/util/colors";
-import vuetifyConfig from "@girder/components/src/utils/vuetifyConfig.js";
+import girderVuetifyConfig from "@girder/components/src/utils/vuetifyConfig.js";
+import { merge } from "lodash";
 
 import "@mdi/font/css/materialdesignicons.css";
 
 Vue.use(Vuetify);
-vuetifyConfig.theme.options.customProperties = true;
-vuetifyConfig.theme.dark = true;
-vuetifyConfig.theme.themes.dark = {
-  ...vuetifyConfig.theme.themes.dark,
-  accent: colors.blue.lighten1,
-  primary: "#004787"
-};
 
-export default new Vuetify(vuetifyConfig);
+const appVuetifyConfig = merge(girderVuetifyConfig, {
+  theme: {
+    dark: true,
+    options: {
+      customProperties: true
+    },
+    themes: {
+      dark: {
+        accent: colors.blue.lighten1,
+        primary: colors.blue.base
+      }
+    }
+  }
+});
+
+export default new Vuetify(appVuetifyConfig);


### PR DESCRIPTION
![Screenshot from 2020-04-08 12-45-29](https://user-images.githubusercontent.com/4214172/78810811-e14a0000-7996-11ea-9d1b-021690059ab2.png)


Makes checkboxes white instead of blue, because blue's meaning is already used for "individual track selection" so having it on label and track toggles confuses that meaning.

Uses config merge strategy described in https://github.com/girder/girder_web_components#customizing-vuetify-configuration

fixes #34 