### PR TITLE
Fix video annotation/detection

### DIFF
--- a/client/src/use/useGirderDataset.js
+++ b/client/src/use/useGirderDataset.js
@@ -4,6 +4,7 @@ import {
 
 const ImageSequenceType = 'image-sequence';
 const VideoType = 'video';
+const defaultFrameRate = 30;
 
 export default function useGirderDataset() {
   const girderRest = inject('girderRest');
@@ -12,7 +13,7 @@ export default function useGirderDataset() {
   const imageUrls = ref([]);
   const videoUrl = ref(null);
 
-  const frameRate = computed(() => dataset.value && dataset.value.meta.fps);
+  const frameRate = computed(() => (dataset.value && dataset.value.meta.fps) || defaultFrameRate);
 
   const annotatorType = computed(() => {
     if (!dataset.value) {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -170,8 +170,7 @@ export default {
           this.girderRest.put(
             `/item/${csvFile.itemId}/metadata?allowNull=true`,
             {
-              folderId: folder._id,
-              pipeline: null,
+              detection: folder._id,
             },
           );
         });

--- a/server/viame_server/__init__.py
+++ b/server/viame_server/__init__.py
@@ -53,4 +53,6 @@ class GirderPlugin(plugin.GirderPlugin):
             "check_annotations",
             check_existing_annotations,
         )
-        events.bind("model.upload.finalize", "fileUpload", maybe_mark_folder_for_annotation)
+        events.bind(
+            "model.upload.finalize", "fileUpload", maybe_mark_folder_for_annotation
+        )

--- a/server/viame_server/event.py
+++ b/server/viame_server/event.py
@@ -9,7 +9,7 @@ def check_existing_annotations(event):
 
     if "annotations.csv" in info["importPath"]:
         item = Item().findOne({"_id": info["id"]})
-        item["meta"].update({"folderId": str(item["folderId"]), "pipeline": None})
+        item["meta"].update({"detection": str(item["folderId"])})
         Item().save(item)
 
         folder = Folder().findOne({"_id": item["folderId"]})

--- a/server/viame_server/event.py
+++ b/server/viame_server/event.py
@@ -3,6 +3,7 @@ from girder.models.item import Item
 
 
 validImageFormats = {"png", "jpg", "jpeg"}
+validVideoFormats = {"avi", "mp4", "mov"}
 
 
 def check_existing_annotations(event):
@@ -29,6 +30,8 @@ def maybe_mark_folder_for_annotation(event):
     parent = Folder().findOne({"_id": info["parentId"]})
 
     fileType = info["mimeType"].split("/")[-1]
-    if fileType in validImageFormats and parent["meta"].get("viame"):
+    validFileType = fileType in validImageFormats or fileType in validVideoFormats
+
+    if validFileType and parent["meta"].get("viame"):
         parent["meta"]["annotate"] = True
         Folder().save(parent)

--- a/server/viame_server/event.py
+++ b/server/viame_server/event.py
@@ -1,9 +1,7 @@
 from girder.models.folder import Folder
 from girder.models.item import Item
 
-
-validImageFormats = {"png", "jpg", "jpeg"}
-validVideoFormats = {"avi", "mp4", "mov"}
+from .utils import validImageFormats, validVideoFormats
 
 
 def check_existing_annotations(event):

--- a/server/viame_server/utils.py
+++ b/server/viame_server/utils.py
@@ -2,6 +2,10 @@ from girder.models.item import Item
 from girder.models.folder import Folder
 
 
+validImageFormats = {"png", "jpg", "jpeg"}
+validVideoFormats = {"avi", "mp4", "mov"}
+
+
 # Ad hoc way to guess the FPS of an Image Sequence based on file names
 # Currently not being used, can only be used once you know that all items
 # have been imported.
@@ -40,11 +44,7 @@ def move_existing_result_to_auxiliary_folder(folder, user):
     auxiliary = get_or_create_auxiliary_folder(folder, user)
 
     existingResultItem = Item().findOne(
-        {
-            "folderId": folder["_id"],
-            "meta.folderId": str(folder["_id"]),
-            "meta.pipeline": {"$exists": True},
-        }
+        {"meta.detection": folder["_id"], "folderId": folder["_id"]}
     )
     if existingResultItem:
         Item().move(existingResultItem, auxiliary)


### PR DESCRIPTION
This PR does two main things:

1. Updates the event listener to add the annotate metadata when uploading a video, as well as an image
2. Changes the metadata on folders/items, to work in a more sensible way. 

Now, the metadata structure is as follows:

* Folders have a metadata structure of:
```
annotate: true | false
fps: Int
type: "video" | "image-sequence"
viame: true
```

* Result detection items have a metadata structure of:
```
detection: <folderId>
```

The value of the detection field represents the folder to which the detections belong. Ideally, I think to keep track of videos more appropriately, we should find a way to set a "video" field on the folder metadata, with the item ID of the video for that folder. However, that's not possible with our current event listeners, as the event we receive is triggered before the item is created. 
