### PR TITLE
Persist annotations

### DIFF
--- a/client/src/components/annotators/annotator.js
+++ b/client/src/components/annotators/annotator.js
@@ -33,6 +33,11 @@ export default {
       syncedFrame: 0,
     };
   },
+  watch: {
+    playing(newval) {
+      this.$emit('playing-state-changed', newval);
+    },
+  },
   created() {
     this.provided.$on('prev-frame', this.prevFrame);
     this.provided.$on('next-frame', this.nextFrame);

--- a/client/src/components/layers/EditAnnotationLayer.vue
+++ b/client/src/components/layers/EditAnnotationLayer.vue
@@ -57,7 +57,9 @@ export default {
   methods: {
     persist() {
       this.$geojsLayer.annotations().forEach((a) => {
-        a.state('done');
+        if (a.state() === 'edit') {
+          a.state('done');
+        }
       });
     },
     reinitialize() {

--- a/client/src/components/layers/EditAnnotationLayer.vue
+++ b/client/src/components/layers/EditAnnotationLayer.vue
@@ -55,6 +55,11 @@ export default {
     delete this.$geojsLayer;
   },
   methods: {
+    persist() {
+      this.$geojsLayer.annotations().forEach((a) => {
+        a.state('done');
+      });
+    },
     reinitialize() {
       this.$geojsLayer.geoOff(geo.event.annotation.mode);
       this.$geojsLayer.geoOff(geo.event.annotation.state);

--- a/client/src/use/useSave.js
+++ b/client/src/use/useSave.js
@@ -1,18 +1,18 @@
 import { ref, inject } from '@vue/composition-api';
 
 export default function useSave() {
-  const pendingSave = ref(false); // true indicates dirty save state
+  const pendingSaveCount = ref(0);
   const girderRest = inject('girderRest');
 
   async function save(datasetId, detections) {
     // TODO: refactor to girder client library
     await girderRest.put(`viame_detection?folderId=${datasetId}`, detections.value);
-    pendingSave.value = false;
+    pendingSaveCount.value = 0;
   }
 
   function markChangesPending() {
-    pendingSave.value = true;
+    pendingSaveCount.value += 1;
   }
 
-  return { save, markChangesPending, pendingSave };
+  return { save, markChangesPending, pendingSaveCount };
 }

--- a/client/src/views/Viewer/Viewer.vue
+++ b/client/src/views/Viewer/Viewer.vue
@@ -166,6 +166,11 @@ export default defineComponent({
       persistAnnotations();
       playbackComponent.value.prevFrame();
     }
+    function handlePlayingStateChanged(newval) {
+      if (newval) {
+        persistAnnotations();
+      }
+    }
     function gotoTrackFirstFrame({ trackId }) {
       setTrackEditMode(trackId, false);
       const _frame = eventChartData.value.find((d) => d.track === trackId)
@@ -274,10 +279,11 @@ export default defineComponent({
       // imported helper methods without side-effects
       getPathFromLocation,
       // miscellaneous oddities
-      playbackComponent,
       annotationRectEditor,
-      swapMousetrap,
       editingBoxLayerStyle,
+      handlePlayingStateChanged,
+      playbackComponent,
+      swapMousetrap,
     };
   },
 });
@@ -399,6 +405,7 @@ export default defineComponent({
           :video-url="videoUrl"
           :frame-rate="frameRate"
           @frame-update="frame = $event"
+          @playing-state-changed="handlePlayingStateChanged"
         >
           <template slot="control">
             <Controls />
@@ -446,7 +453,7 @@ export default defineComponent({
             @annotation-right-click="annotationRightClick"
           />
           <edit-annotation-layer
-            v-if="editingTrackId !== null"
+            v-if="editingTrackId !== null && !playbackComponent.playing"
             ref="annotationRectEditor"
             editing="rectangle"
             :geojson="editingDetectionGeojson"


### PR DESCRIPTION
When you edit an annotation, then change the current frame, the annotation is lost.  IMO, this is a large usability bug. This change makes it so frame-changes add annotation modifications to the queue and cause the save button to appear.

Workflow becomes: adjust, press f, adjust, press f...

![output](https://user-images.githubusercontent.com/4214172/79609740-44d5db00-80c5-11ea-9b09-7adbd76f575c.gif)

Adds a badge on the save icon to show how many outstanding changes are currently unsaved.

