### PR TITLE
Creation of subfolders while uploading

### DIFF
--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -405,7 +405,7 @@ export default {
                 />
               </v-col>
               <v-col
-                v-if="pendingUpload.uploadLocation"
+                v-if="pendingUpload.uploadLocation === 'folder'"
                 cols="2"
               >
                 <v-text-field

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -49,6 +49,13 @@ export default {
       return this.selectedEligibleClips.length < 1 || !this.pipelines.length;
     },
   },
+  watch: {
+    uploading(newval) {
+      if (!newval) {
+        this.$refs.fileManager.$refs.girderBrowser.refresh();
+      }
+    },
+  },
   created() {
     this.location_ = getLocationFromRoute(this.$route);
     this.setLocation(this.location_);
@@ -120,7 +127,6 @@ export default {
       }
     },
     uploaded(uploads) {
-      this.$refs.fileManager.$refs.girderBrowser.refresh();
       this.uploaderDialog = false;
 
       // transcode video


### PR DESCRIPTION
fixes #41 
Swapped the 'create Folder' checkbox to be a dropdown allowing the user to choose between:
- Folder (creation of a folder for the files)
- Current (upload files to the current location)
- Subfolder (create a subfolder for each file)
It will check the uploaded files and try to determine automatically which mode to select.

![image](https://user-images.githubusercontent.com/61746913/79781627-bdc67400-830b-11ea-98c6-e61e9f1d7c15.png)

Structural changes to upload.vue:
- created regular expressions for filtering Images and Video files.  They are used in a few places so figured abstract that out.
- added in the upload location types
- Added in suggested upload location based on files
- Split the pendingUpload function into folder creation and file upload.  This was necessary to support the subfolders.  I wanted to use the existing functionality of the uploadMixin and the fact that the existing uploaded folders properly set annotations.