### PR TITLE
Shrink dockerfile, fix issue with docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+**/node_modules
+**/dist
+**/build
+docker/girder_data

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ docker-compose -f docker/docker-compose.yml up
 
 VIAME server will be running at http://localhost:8010/
 
+> **Note:** In order to build images yourself, the `.git` folder must exist, so you must `git clone` from source control.  A release archive zip can be used too, but only to run pre-built images from a container registry.
+
 ## Example Data
 
 ### Input

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   publicPath: process.env.VUE_APP_STATIC_PATH,
   chainWebpack: (config) => {
+    config.output.strictModuleExceptionHandling(true);
     config.resolve.symlinks(false);
   },
 };

--- a/docker/girder.Dockerfile
+++ b/docker/girder.Dockerfile
@@ -1,24 +1,40 @@
-FROM girder/girder:latest
+FROM node:latest as builder
+WORKDIR /app
+# Install dependencies
+COPY client/package.json client/yarn.lock /app/
+RUN yarn --frozen-lockfile
+# Build
+COPY .git/ /app/.git/
+COPY client/ /app/
+RUN yarn build
+
+
+FROM python:3.7-slim as runtime
+EXPOSE 8080
+# Set environment to support Unicode: http://click.pocoo.org/5/python3/#python-3-surrogate-handling
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+WORKDIR /girder
+COPY --from=girder/girder:latest /girder/ /girder/
+# avoid psutil GCC dependency by using unofficial large_image wheel
+RUN apt-get update \
+  && apt-get install -qy git \
+  && pip install \
+    --no-cache-dir \
+    --find-links https://girder.github.io/large_image_wheels \
+    --upgrade-strategy eager . \
+  && apt-get remove --purge -qy git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /girder/.git
+COPY --from=girder/girder:latest /usr/share/girder/static/ /usr/local/share/girder/static/
 
 WORKDIR /home
-
-RUN pip install --no-cache-dir \
-        girder-jobs \
-        girder-worker \
-    && girder build
-
 # modify this based on where you are running docker-compose from
 COPY docker/provision provision
-
 COPY server viame_girder
-
 RUN cd viame_girder && pip install --no-cache-dir .
-
-# Build the client and serve it via girder
-COPY client viame_client
-
-RUN cd viame_client && npm install && npm run build && \
-    mkdir /usr/share/girder/static/viame && \
-    cp -r dist/* /usr/share/girder/static/viame/
+# Bring in the client from girder
+COPY --from=builder /app/dist/ /usr/local/share/girder/static/viame/
 
 ENTRYPOINT ["/home/provision/girder_entrypoint.sh"]


### PR DESCRIPTION
This fixes the issues with docker build and shrinks the docker image down to a reasonableish 600MB.

We will be able to get a much smaller one in the near future.