### PR TITLE
Enhancement/image cache

### DIFF
--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -12,8 +12,13 @@ export default {
       required: true,
     },
   },
-
+  data() {
+    return {
+      loadingVideo: false,
+    };
+  },
   created() {
+    this.playCache = 1; // seconds to cache
     this.maxFrame = this.imageUrls.length - 1;
     this.imgs = new Array(this.imageUrls.length);
     this.pendingImgs = new Set();
@@ -58,6 +63,7 @@ export default {
     },
 
     async seek(frame) {
+      this.lastFrame = this.frame;
       this.frame = frame;
       this.syncedFrame = frame;
       this.emitFrame();
@@ -75,6 +81,7 @@ export default {
 
     pause() {
       this.playing = false;
+      this.loadingVideo = false;
     },
 
     onResize() {
@@ -97,36 +104,108 @@ export default {
           this.syncedFrame = this.maxFrame;
           return;
         }
+        if (!this.imgs[this.frame].cached || this.loadingVideo) {
+          this.frame -= 1;
+          this.loadingVideo = true;
+          return;
+        }
         this.seek(this.frame);
         setTimeout(this.syncWithVideo, 1000 / this.frameRate);
       }
     },
-    cacheImage() {
+    async cacheImage() {
       const { frame } = this;
-      const max = Math.min(frame + 10, this.maxFrame);
       const { imgs } = this;
+      // First thing we do is wait for the current frame to load
+
+      const cacheSeconds = 3;
+      const cachedFrames = cacheSeconds * this.frameRate;
+      const frontBackRatio = 1.00; // 75% forward frames, 25% backward frames
+      const min = Math.max(0, frame - cachedFrames * (1 - frontBackRatio));
+      const max = Math.min(frame + frontBackRatio * cachedFrames, this.maxFrame);
+      const frameDiff = Math.abs(this.frame - this.lastFrame);
       this.pendingImgs.forEach((imageAndFrame) => {
-        if (imageAndFrame[1] < frame || imageAndFrame[1] > max) {
+        if (imageAndFrame[1] < min || imageAndFrame[1] > max || frameDiff > 2) {
           imgs[imageAndFrame[1]] = null;
+          // eslint-disable-next-line no-console
+          console.log(`${imageAndFrame[1]} -CACHE CLEAR min:${min} max:${max}`);
           // eslint-disable-next-line no-param-reassign
           imageAndFrame[0].src = '';
           this.pendingImgs.delete(imageAndFrame);
         }
       });
+      if (!this.playing && frame > 0) {
+        // eslint-disable-next-line no-console
+        console.log('awaiting load frame');
+        const result = await this.loadFrame(frame);
+        // eslint-disable-next-line no-console
+        console.log(result);
+      }
+
+      this.cacheNewRange(frame, max);
+    },
+    loadFrame(frame) {
+      return new Promise((resolve) => {
+        const img = new Image();
+        img.crossOrigin = 'Anonymous';
+        img.src = this.imageUrls[frame];
+        // eslint-disable-next-line no-param-reassign
+        this.imgs[frame] = img;
+        img.onload = () => {
+          img.onload = null;
+          img.cached = true;
+          resolve(frame);
+        };
+      });
+    },
+    cacheNewRange(frame, max) {
       for (let i = frame; i <= max; i += 1) {
-        if (!imgs[i]) {
+        if (!this.imgs[i]) {
           const img = new Image();
           img.crossOrigin = 'Anonymous';
           img.src = this.imageUrls[i];
-          imgs[i] = img;
+          // eslint-disable-next-line no-param-reassign
+          this.imgs[i] = img;
           const imageAndFrame = [img, frame];
           this.pendingImgs.add(imageAndFrame);
           img.onload = () => {
             this.pendingImgs.delete(imageAndFrame);
             img.onload = null;
+            img.cached = true;
+            // If we are trying to play and waiting for loaded frames we check the cache again
+            if (this.playing && this.loadingVideo) {
+              if (this.checkCached(this.playCache)) {
+                this.loadingVideo = false;
+                this.syncWithVideo();
+              }
+            }
           };
         }
       }
+    },
+    /**
+     * Checks to see if there is enough cached images to play for X seconds
+     * @param {int} seconds - the number of seconds to look for the cache
+     * @returns {boolean}
+     */
+    checkCached(seconds) {
+      const { frame } = this;
+      const max = Math.min(frame + seconds * this.frameRate, this.maxFrame);
+      // Lets work our way in from both sides for faster checking
+      for (let i = frame; i <= frame + (max - frame) / 2; i += 1) {
+        // eslint-disable-next-line no-console
+        console.log(`frame${frame} max${max}`);
+        if (!(this.imgs[i].cached && this.imgs[max - i].cached)) {
+          // eslint-disable-next-line no-console
+          console.log(`frame[${i}] is: ${this.imgs[i].cached} frame[${max - i}] is: ${this.imgs[max - i].cached}`);
+          return false;
+        }
+      }
+      // eslint-disable-next-line no-console
+      console.log(`frame[${frame + 1}] is: ${this.imgs[frame + 1].complete}`);
+      // eslint-disable-next-line no-console
+      console.log(`Checked ${frame} - ${max}`);
+      return true;
     },
   },
 };
@@ -142,6 +221,18 @@ export default {
       class="playback-container"
     >
       {{ rendered() }}
+      <div class="loadingSpinnerContainer">
+        <v-progress-circular
+          v-if="loadingVideo"
+          class="loadingSpinner"
+          indeterminate
+          size="100"
+          width="15"
+          color="light-blue"
+        >
+          Loading
+        </v-progress-circular>
+      </div>
     </div>
     <slot name="control" />
     <slot v-if="ready" />

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -23,14 +23,6 @@ export default {
     this.cacheSeconds = 6; // seconds to cache from the current frame
     this.frontBackRatio = 0.90; // 90% forward frames, 10% backward frames when caching
 
-    // playCache needs to be less than the adjusted cache seconds to work properly
-    if (this.playCache > this.cacheSeconds * this.frontBackRatio) {
-      const difference = (this.playCache - (this.cacheSeconds * this.frontBackRatio));
-      this.cacheSeconds = Math.ceil(this.cacheSeconds + difference);
-    }
-    if (this.frontBackRatio > 1 || this.frontBackRatio < 0) {
-      this.frontBackRatio = 1.0;
-    }
     this.maxFrame = this.imageUrls.length - 1;
     this.imgs = new Array(this.imageUrls.length);
     this.pendingImgs = new Set();
@@ -183,8 +175,8 @@ export default {
     /**
      * Caches a new range of frames to load in a forward->back pattern from the current frame
      * This allows for easily seeking backwards after seeking initially
-     * @param {int} min - lower bound frame number for caching
-     * @param {int} max - upper bound frame number for caching
+     * @param {int} min lower bound frame number for caching
+     * @param {int} max upper bound frame number for caching
      */
     cacheNewRange(min, max) {
       for (let i = this.frame; i <= max; i += 1) {
@@ -198,7 +190,7 @@ export default {
     /**
      * Adds a single frame to the pendingImgs array for loading and assigns it to the master
      * imgs list. Once the image is loaded it is removed from the pendingImgs
-     * @param {int} i - the image to cache if it isn't already assigned
+     * @param {int} i the image to cache if it isn't already assigned
      */
     cacheFrame(i) {
       if (!this.imgs[i]) {
@@ -225,8 +217,8 @@ export default {
     },
     /**
      * Checks to see if there is enough cached images to play for X seconds
-     * @param {int} seconds - the number of seconds to look for the cache
-     * @returns {boolean} - true if the cache is valid for the next X seconds,
+     * @param {int} seconds the number of seconds to look for the cache
+     * @returns {boolean} true if the cache is valid for the next X seconds,
      * otherwise false.
      */
     checkCached(seconds) {

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -20,7 +20,7 @@ export default {
   created() {
     // Below are configuration settings we can set until we decide on good numbers to utilize.
     this.playCache = 1; // seconds required to be fully cached before playback
-    this.cacheSeconds = 3; // seconds to cache from the current frame
+    this.cacheSeconds = 6; // seconds to cache from the current frame
     this.frontBackRatio = 0.90; // 90% forward frames, 10% backward frames when caching
 
     // playCache needs to be less than the adjusted cache seconds to work properly

--- a/client/src/components/annotators/annotator.scss
+++ b/client/src/components/annotators/annotator.scss
@@ -16,4 +16,14 @@
       outline: none;
     }
   }
+  .loadingSpinnerContainer {
+    z-index: 1;
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -ms-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+  }
 }
+


### PR DESCRIPTION
Fixes #13 
Improves the image caching system to prevent the playing of black/blank frames.
Adds in a variable `playCache` which requires a number of seconds to be cached before continuing with playback.  If the images aren't available a loading screen will display.
Adds in a variable `cacheSeconds` specifying the number of seconds to cache images which is then subdivided between forward cache and backwards cache using `frontBackRatio`
`Image.complete` is [unreliable](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/complete) in the sense that it will be marked as true when no src has been set or the src is empty.  I'm using my own `image.cached` boolean attached to loaded images to track caching.

The caching system will now clear pending items itself after a seek or a drag backwards.  It will also prioritize the current frame when dragging or seeking instead of waiting for the cache to load the frame.  You can still get black frames when seeking, but they should resolve faster.

For testing purposes I would suggest creating a custom network profile in the chrome network tab and set the download speed to ~73Mbps.  This works fairly well with the Ehu test data.  Just enough where it isn't painful to load but will still cause some loading during typical playback.

