### PR TITLE
Enhancement/track improvements

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -60,6 +60,7 @@ export default {
     editing(val) {
       if (val) {
         this.$nextTick(() => {
+          this.$refs.trackTypeBox.focus();
           this.$refs.trackTypeBox.activateMenu();
         });
       }
@@ -110,7 +111,6 @@ export default {
     <v-combobox
       v-else
       ref="trackTypeBox"
-      :autofocus="true"
       class="ml-2"
       :value="track.confidencePairs.length ? track.confidencePairs[0][0] : ''"
       :items="types"

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -47,6 +47,10 @@ export default {
       }
       return {};
     },
+
+    comboValue() {
+      return this.track.confidencePairs.length ? this.track.confidencePairs[0][0] : '';
+    },
   },
   watch: {
     track() {
@@ -72,6 +76,12 @@ export default {
         this.editing = true;
       }
     },
+    handleChange(newval) {
+      this.editing = false;
+      if (newval !== this.comboValue) {
+        this.$emit('type-change', newval);
+      }
+    },
   },
 };
 </script>
@@ -87,7 +97,7 @@ export default {
       dense
       hide-details
       :input-value="inputValue"
-      :color="colorMap(track.confidencePairs.length ? track.confidencePairs[0][0] : '')"
+      :color="colorMap(comboValue)"
       @change="$emit('change', $event)"
     />
     <div
@@ -104,19 +114,17 @@ export default {
       class="type-display flex-grow-1 flex-shrink-1 ml-2"
       @click="editing = true"
     >
-      {{
-        track.confidencePairs.length ? track.confidencePairs[0][0] : "undefined"
-      }}
+      {{ comboValue || 'undefined' }}
     </div>
     <v-combobox
       v-else
       ref="trackTypeBox"
       class="ml-2"
-      :value="track.confidencePairs.length ? track.confidencePairs[0][0] : ''"
+      :value="comboValue"
       :items="types"
       dense
       hide-details
-      @change="$emit('type-change', $event)"
+      @input="handleChange"
     />
     <v-menu offset-y>
       <template v-slot:activator="{ on }">

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -35,7 +35,8 @@ export default {
   computed: {
     /**
      * Sets styling for the selected track
-     * Sets the accent color to have a slight opacity so it isn't overwhelming
+     * Sets the background accent color to have a slight
+     * opacity so it isn't overwhelming
      */
     style() {
       if (this.selectedTrackId === this.track.trackId) {
@@ -50,6 +51,25 @@ export default {
   watch: {
     track() {
       this.editing = false;
+    },
+    /**
+     * When editing is enabled through Keyboard Shortcut this will provide focus
+     * and open the menu so the use can choose an item with the keyboard
+     * nextTick is used because the ref isn't rendered until editing is true
+     */
+    editing(val) {
+      if (val) {
+        this.$nextTick(() => {
+          this.$refs.trackTypeBox.activateMenu();
+        });
+      }
+    },
+  },
+  methods: {
+    focusType() {
+      if (this.selectedTrackId === this.track.trackId) {
+        this.editing = true;
+      }
     },
   },
 };
@@ -66,7 +86,7 @@ export default {
       dense
       hide-details
       :input-value="inputValue"
-      :color="colorMap(track.confidencePairs[0][0])"
+      :color="colorMap(track.confidencePairs.length ? track.confidencePairs[0][0] : '')"
       @change="$emit('change', $event)"
     />
     <div
@@ -77,6 +97,9 @@ export default {
     </div>
     <div
       v-if="!editing"
+      v-mousetrap="[
+        { bind: 'shift+enter', handler: focusType },
+      ]"
       class="type-display flex-grow-1 flex-shrink-1 ml-2"
       @click="editing = true"
     >
@@ -86,6 +109,8 @@ export default {
     </div>
     <v-combobox
       v-else
+      ref="trackTypeBox"
+      :autofocus="true"
       class="ml-2"
       :value="track.confidencePairs.length ? track.confidencePairs[0][0] : ''"
       :items="types"

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -24,10 +24,29 @@ export default {
       validator: stringNumberNullValidator,
       required: true,
     },
+    colorMap: {
+      type: Function,
+      required: true,
+    },
   },
   data: () => ({
     editing: false,
   }),
+  computed: {
+    /**
+     * Sets styling for the selected track
+     * Sets the accent color to have a slight opacity so it isn't overwhelming
+     */
+    style() {
+      if (this.selectedTrackId === this.track.trackId) {
+        return {
+          'font-weight': 'bold',
+          'background-color': `${this.$vuetify.theme.themes.dark.accent}aa`,
+        };
+      }
+      return {};
+    },
+  },
   watch: {
     track() {
       this.editing = false;
@@ -39,20 +58,21 @@ export default {
 <template>
   <div
     class="track-item d-flex align-center hover-show-parent px-1"
-    :class="{
-      selected: selectedTrackId === track.trackId
-    }"
-    @click.self="$emit('click')"
+
+    :style="style"
   >
     <v-checkbox
       class="my-0 ml-1 pt-0"
       dense
       hide-details
       :input-value="inputValue"
-      color="neutral"
+      :color="colorMap(track.confidencePairs[0][0])"
       @change="$emit('change', $event)"
     />
-    <div>
+    <div
+      class="trackNumber"
+      @click.self="$emit('click')"
+    >
       {{ track.trackId + (editingTrackId === track.trackId ? "*" : "") }}
     </div>
     <div
@@ -104,7 +124,12 @@ export default {
 <style lang="scss" scoped>
 .track-item {
   height: 45px;
-
+  .trackNumber{
+    &:hover {
+      cursor: pointer;
+      font-weight: bolder;
+    }
+}
   .type-display {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/client/src/components/Tracks.vue
+++ b/client/src/components/Tracks.vue
@@ -31,11 +31,26 @@ export default {
       validator: stringNumberNullValidator,
       required: true,
     },
+    colorMap: {
+      type: Function,
+      required: true,
+    },
   },
   data() {
-    return { checkedTracks_: this.checkedTracks, item: TrackItem };
+    return {
+      checkedTracks_: this.checkedTracks,
+      item: TrackItem,
+      visibleItems: 9,
+    };
   },
   computed: {
+    /**
+     * Computes the offset for displaying the item on the screen
+     * When selecting from track list or elswehere we want to try
+     * to center the item in the list.
+     * When iterating through using the keyboard we keep it at the bottom once they
+     * get above the list size
+     */
     selectedOffset() {
       return this.tracks.map((item) => item.trackId).indexOf(this.selectedTrackId);
     },
@@ -49,6 +64,9 @@ export default {
     },
   },
   methods: {
+    getSelectedTrack() {
+      return this.tracks.find((track) => track.trackId === this.selectedTrackId);
+    },
     getItemProps(itemIndex) {
       const track = this.tracks[itemIndex];
       return {
@@ -57,6 +75,7 @@ export default {
           inputValue: this.checkedTracks_.indexOf(track.trackId) !== -1,
           selectedTrackId: this.selectedTrackId,
           editingTrackId: this.editingTrackId,
+          colorMap: this.colorMap,
           types: this.types,
         },
         on: {
@@ -78,7 +97,8 @@ export default {
             this.$emit('delete-track', track);
           },
           click: () => {
-            this.$emit('click-track', track);
+            this.$emit('click-track', track.trackId);
+            this.$emit('goto-track-first-frame', track);
           },
           edit: () => {
             this.$emit('edit-track', track);
@@ -101,6 +121,12 @@ export default {
       </v-btn>
     </v-subheader>
     <virtual-list
+      v-mousetrap="[
+        { bind: 'del', handler: () => $emit('delete-track', getSelectedTrack()) },
+        { bind: 'up', handler: () => $emit('select-track-up') },
+        { bind: 'down', handler: () => $emit('select-track-down') },
+        { bind: 'enter', handler: () => $emit('goto-track-first-frame', getSelectedTrack()) }
+      ]"
       :size="45"
       :remain="9"
       :start="selectedOffset"

--- a/client/src/components/Tracks.vue
+++ b/client/src/components/Tracks.vue
@@ -45,14 +45,16 @@ export default {
   },
   computed: {
     /**
-     * Computes the offset for displaying the item on the screen
-     * When selecting from track list or elswehere we want to try
-     * to center the item in the list.
-     * When iterating through using the keyboard we keep it at the bottom once they
-     * get above the list size
+     * Computes the offset for the virtual scroll list and highlighting
      */
     selectedOffset() {
-      return this.tracks.map((item) => item.trackId).indexOf(this.selectedTrackId);
+      let offset = this.tracks.map((item) => item.trackId).indexOf(this.selectedTrackId);
+      if (offset === -1) {
+        offset = this.tracks.length - 1;
+      } else {
+        offset -= Math.floor(this.visibleItems / 2);
+      }
+      return offset;
     },
   },
   watch: {

--- a/client/src/use/useEditingLayer.js
+++ b/client/src/use/useEditingLayer.js
@@ -13,8 +13,12 @@ export default function useEditingLayer({
   deleteDetection,
   setDetection,
 }) {
-  async function deleteTrack({ trackId }) {
-    if (typeof trackId !== 'string') {
+  async function deleteTrack(track) {
+    if (!track) {
+      return;
+    }
+    const { trackId } = track;
+    if (typeof trackId !== 'number') {
       throw new Error('Must provide object with key `trackId` to deleteTrack()');
     }
     const _detections = detections.value;

--- a/client/src/use/useSelectionControls.js
+++ b/client/src/use/useSelectionControls.js
@@ -66,6 +66,23 @@ export default function useSelectionControls({
     selectedTrackId.value = trackid;
   }
 
+  function selectNextTrack() {
+    let index = tracks.value.findIndex((track) => track.trackId === selectedTrackId.value);
+    if (index < tracks.value.length - 1) {
+      index += 1;
+    }
+    selectedTrackId.value = tracks.value[index].trackId;
+  }
+
+  function selectPreviousTrack() {
+    let index = tracks.value.findIndex((track) => track.trackId === selectedTrackId.value);
+    if (index < 0) {
+      index = 0;
+    } else if (index > 0) {
+      index -= 1;
+    }
+    selectedTrackId.value = tracks.value[index].trackId;
+  }
   function setTrackEditMode(trackid, editing = true) {
     selectTrack(trackid);
     editingTrack.value = editing;
@@ -86,6 +103,8 @@ export default function useSelectionControls({
     selectedDetectionIndex,
     selectedDetection,
     selectTrack,
+    selectNextTrack,
+    selectPreviousTrack,
     setTrackEditMode,
     deleteSelectedDetection,
   };

--- a/client/src/views/Viewer/Viewer.vue
+++ b/client/src/views/Viewer/Viewer.vue
@@ -86,6 +86,8 @@ export default defineComponent({
       selectedDetectionIndex,
       selectedDetection,
       setTrackEditMode,
+      selectNextTrack,
+      selectPreviousTrack,
     } = useSelectionControls({
       frame,
       detections,
@@ -231,6 +233,8 @@ export default defineComponent({
       selectedTrackId,
       selectedDetection,
       setTrackEditMode,
+      selectNextTrack,
+      selectPreviousTrack,
       // Save
       save,
       pendingSaveCount,
@@ -366,13 +370,16 @@ export default defineComponent({
               :checked-tracks.sync="checkedTracks"
               :selected-track-id="selectedTrackId"
               :editing-track-id="editingTrackId"
+              :color-map="typeColorMap"
               class="flex-shrink-0"
               @goto-track-first-frame="gotoTrackFirstFrame"
               @edit-track="editTrack"
-              @click-track="editTrack"
+              @click-track="setTrackEditMode($event, false)"
               @track-type-change="trackTypeChanged"
               @add-track="addTrack"
               @delete-track="deleteTrack"
+              @select-track-up="selectPreviousTrack"
+              @select-track-down="selectNextTrack"
             />
           </div>
           <div


### PR DESCRIPTION
Resolves #51
Resolves #52 
Resolves #53 
User interface updates for interaction with Tracks to allow for more keyboard events.
**Key Up**: go up in the track list
**Key Down**: go down in the track list
**Enter**: to the first frame of the selected track
**Shift+Enter**: Edit the type for the currently selected track (allows using the arrow keys for choosing existing type, or you can type up a new type)
**Left/Right**: still used for scrubbing in the video
**Delete Key**:  Deletes the currently selected track
Clicking on the Number for a Track:  Cursor changes to pointer, clicking on it will select it and go to the first frame of the track

I like Brandon's styling for the Typelist checkboxes so I implemented the same for the track list.  I reduced the opacity of the highlight color so it wasn't overwhelming the colors.

**Notes:**
Within `useEditingLayer.js` it was checking to see if the trackId was a string.  In Ehu and most other sims it looks like trackIds are always numbers.  I was getting errors while using it.  I also changed it to not deconstruct the input argument because I wanted it to gracefully fail if a user clicked the delete key with no track selected

To open the v-menu for the Typelist dropdown on a keyboard shortcut I needed to watch the editing state change.  Then call `activateMenu()` afterwards.  The component doesn't exist until `editing` is true, so on the next frame I need to activateMenu.  That is why I'm using `nextTick` but am open to alternatives if we want to restructure the dropdown component.

**Next Steps**
Make it so the confirmation dialog also supports keyboard focus.  This would make it much easier to go through and delete necessary tracks.
Once this is approved modify the help functionality to display the newer keyboard shortcuts.