### PR TITLE
Bugfix/click misses

### DIFF
--- a/client/src/components/layers/AnnotationLayer.vue
+++ b/client/src/components/layers/AnnotationLayer.vue
@@ -67,6 +67,27 @@ export default {
           this.$emit('annotation-right-click', e.data.record, e);
         }
       });
+    this.polygonFeature.geoOn(geo.event.feature.mousemove, (e) => {
+      const calcVel = Math.abs(e.mouse.velocity.x) + Math.abs(e.mouse.velocity.y);
+      const interactorOpts = this.annotator.geoViewer.interactor().options();
+      const { cancelOnMove } = interactorOpts.click;
+      if (cancelOnMove && calcVel < 1) {
+        interactorOpts.click.cancelOnMove = false;
+      } else if (!cancelOnMove) {
+        interactorOpts.click.cancelOnMove = true;
+      }
+      if (cancelOnMove !== interactorOpts.click.cancelOnMove) {
+        this.annotator.geoViewer.interactor().options(interactorOpts);
+      }
+    });
+    this.polygonFeature.geoOn(geo.event.feature.mouseoff, () => {
+      const interactorOpts = this.annotator.geoViewer.interactor().options();
+      const { cancelOnMove } = interactorOpts.click;
+      interactorOpts.click.cancelOnMove = true;
+      if (cancelOnMove !== interactorOpts.click.cancelOnMove) {
+        this.annotator.geoViewer.interactor().options(interactorOpts);
+      }
+    });
     this.polygonFeature.geoOn(
       geo.event.feature.mouseclick_order,
       this.polygonFeature.mouseOverOrderClosestBorder,

--- a/client/src/components/layers/AnnotationLayer.vue
+++ b/client/src/components/layers/AnnotationLayer.vue
@@ -67,6 +67,9 @@ export default {
           this.$emit('annotation-right-click', e.data.record, e);
         }
       });
+    /* cancelOnMove = true will prevent clicks from registering if the user moves the cursor at all
+     this can make it hard to click on items
+     This will change the value based on being inside an annotation and amount of mouse movement */
     this.polygonFeature.geoOn(geo.event.feature.mousemove, (e) => {
       const calcVel = Math.abs(e.mouse.velocity.x) + Math.abs(e.mouse.velocity.y);
       const interactorOpts = this.annotator.geoViewer.interactor().options();
@@ -76,10 +79,12 @@ export default {
       } else if (!cancelOnMove) {
         interactorOpts.click.cancelOnMove = true;
       }
+      // Only change the cancelOnMove if it is different
       if (cancelOnMove !== interactorOpts.click.cancelOnMove) {
         this.annotator.geoViewer.interactor().options(interactorOpts);
       }
     });
+    // If the user is not over any annotation we can set cancelOnMove=true
     this.polygonFeature.geoOn(geo.event.feature.mouseoff, () => {
       const interactorOpts = this.annotator.geoViewer.interactor().options();
       const { cancelOnMove } = interactorOpts.click;


### PR DESCRIPTION
Fixes #8 

Key fix is that it should be easier to quickly move the mouse and click on an annotation to select it.


The Velocity comparison on line 77 in `AnnotationLayer.vue` can be tuned to find out what value works best.  I feel `1` works well right now.

GeoJS has a setting for the interface called `click.cancelOnMove` which is set to true by default.  This setting will prevent any click from registering if the mouse is moving at all while the left-button is in the down state.  This is what was causing the missed clicks.  Setting this to false will prevent the user from being able to pan the screen utilizing the left click because it now doesn't know how to register a pan and differentiate it from a click.  There is an option that can be used called `click.duration` which is a number of milliseconds a click must be completed in.  It allows you to specify a time sensitive click but that probably isn't the best.

The way I implemented it to make it work is to change the `cancelOnMove` setting based on the velocity of the mouse (a thing that is recorded during `mouseMove` for an annotation) and if the cursor is over an annotation using `mouseMove`.  There is a velocity that is used to determine how quickly the mouse is being moved right before the click.  It is set to `1` right now.  If the value is over that number it will perform a pan because the cancelOnMove will be set to true.  If it is below that number it will be set to false meaning a click or selection should be registered.