### PR TITLE
Ability to get un-stuck from editing combobox with keyboard

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -47,6 +47,10 @@ export default {
       }
       return {};
     },
+
+    comboValue() {
+      return this.track.confidencePairs.length ? this.track.confidencePairs[0][0] : '';
+    },
   },
   watch: {
     track() {
@@ -72,6 +76,12 @@ export default {
         this.editing = true;
       }
     },
+    handleChange(newval) {
+      this.editing = false;
+      if (newval !== this.comboValue) {
+        this.$emit('type-change', newval);
+      }
+    },
   },
 };
 </script>
@@ -87,7 +97,7 @@ export default {
       dense
       hide-details
       :input-value="inputValue"
-      :color="colorMap(track.confidencePairs.length ? track.confidencePairs[0][0] : '')"
+      :color="colorMap(comboValue)"
       @change="$emit('change', $event)"
     />
     <div
@@ -104,19 +114,17 @@ export default {
       class="type-display flex-grow-1 flex-shrink-1 ml-2"
       @click="editing = true"
     >
-      {{
-        track.confidencePairs.length ? track.confidencePairs[0][0] : "undefined"
-      }}
+      {{ comboValue || 'undefined' }}
     </div>
     <v-combobox
       v-else
       ref="trackTypeBox"
       class="ml-2"
-      :value="track.confidencePairs.length ? track.confidencePairs[0][0] : ''"
+      :value="comboValue"
       :items="types"
       dense
       hide-details
-      @change="$emit('type-change', $event)"
+      @input="handleChange"
     />
     <v-menu offset-y>
       <template v-slot:activator="{ on }">


### PR DESCRIPTION
When a user highlights a track and presses `shift-enter` the enter into edit mode for the combo box.

Currently, there's no way out without using the mouse.  With this change, selection of a different label with arrow keys + enter will exit edit mode and allow the user to continue navigating the list.

To edit the text by typing a new label, `shift-enter` enables typing.   `escape` will close the dropdown without exiting edit mode.  `enter` exits edit mode and returns control to the track list.