### PR TITLE
[bugfix] log out

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ VIAME server will be running at http://localhost:8010/
 
 > **Note:** In order to build images yourself, the `.git` folder must exist, so you must `git clone` from source control.  A release archive zip can be used too, but only to run pre-built images from a container registry.
 
+You can run the data viewer without needing GPU support as well
+
+``` bash
+docker-compose -f docker/docker-compose.yml up girder
+```
+
 ## Example Data
 
 ### Input

--- a/client/src/components/NavigationBar.vue
+++ b/client/src/components/NavigationBar.vue
@@ -28,12 +28,17 @@ export default {
     });
     this.runningJobIds = runningJobs.map((job) => job._id);
     this.notificationBus.$on('message:job_status', this.handleNotification);
+    this.girderRest.$on('logout', this.onLogout);
   },
   beforeDestroy() {
+    this.girderRest.$off('logout', this.onLogout);
     this.notificationBus.$off('message:job_status', this.handleNotification);
   },
   methods: {
     getPathFromLocation,
+    onLogout() {
+      this.$router.push({ name: 'login' });
+    },
     handleNotification({ data: job }) {
       const jobStatus = all();
       const jobId = job._id;


### PR DESCRIPTION
Log out is currently boroken.  

I tacked a small docs update onto this because I spoke with someone who just wanted a way to view KW18 files on their videos, and pulling/building 15GB just to have it sit idle seems like a waste.