### PR TITLE
Add image conversion of non-web-friendly image formats

### DIFF
--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -7,10 +7,13 @@ import {
 
 // Supported File Types
 const videoFileTypes = ['.mp4', '.avi', '.mov', '.mpg'];
-const imageFileTypes = ['.jpg', '.jpeg', '.png', '.bmp'];
+const webFriendlyImageFileTypes = ['.jpg', '.jpeg', '.png'];
+const imageFileTypes = [...webFriendlyImageFileTypes, '.bmp', '.sgi', '.tif', '.tiff', '.pgm'];
+
 // Utility for commonly used regular expressions
 const videoFilesRegEx = new RegExp(videoFileTypes.join('$|'), 'i');
 const imageFilesRegEx = new RegExp(imageFileTypes.join('$|'), 'i');
+const webFriendlyImageRegEx = new RegExp(webFriendlyImageFileTypes.join('$|'), 'i');
 function prepareFiles(files) {
   const videoFilter = (file) => videoFilesRegEx.test(file.name);
   const csvFilter = (file) => /\.csv$/i.test(file.name);
@@ -317,6 +320,15 @@ export default {
           folder,
           results: data.results,
         });
+
+        // Make sure that we don't run the conversion task for no reason
+        const filtered = files.filter(({ file: { name: fileName } }) => (
+          !webFriendlyImageRegEx.test(fileName)
+        ));
+
+        if (filtered.length) {
+          this.girderRest.post('/viame/image_conversion', null, { params: { folder: folder._id } });
+        }
       };
 
       // Sets the files used by the fileUploader mixin

--- a/client/src/components/Upload.vue
+++ b/client/src/components/Upload.vue
@@ -11,9 +11,10 @@ const webFriendlyImageFileTypes = ['.jpg', '.jpeg', '.png'];
 const imageFileTypes = [...webFriendlyImageFileTypes, '.bmp', '.sgi', '.tif', '.tiff', '.pgm'];
 
 // Utility for commonly used regular expressions
-const videoFilesRegEx = new RegExp(videoFileTypes.join('$|'), 'i');
-const imageFilesRegEx = new RegExp(imageFileTypes.join('$|'), 'i');
-const webFriendlyImageRegEx = new RegExp(webFriendlyImageFileTypes.join('$|'), 'i');
+const videoFilesRegEx = new RegExp(`${videoFileTypes.join('$|')}$`, 'i');
+const imageFilesRegEx = new RegExp(`${imageFileTypes.join('$|')}$`, 'i');
+const webFriendlyImageRegEx = new RegExp(`${webFriendlyImageFileTypes.join('$|')}$`, 'i');
+
 function prepareFiles(files) {
   const videoFilter = (file) => videoFilesRegEx.test(file.name);
   const csvFilter = (file) => /\.csv$/i.test(file.name);

--- a/server/viame_server/utils.py
+++ b/server/viame_server/utils.py
@@ -2,9 +2,10 @@ from girder.models.item import Item
 from girder.models.folder import Folder
 
 
-validImageFormats = {"png", "jpg", "jpeg"}
+validImageFormats = {"png", "jpg", "jpeg", "tif", "tiff", "sgi", ".bmp", ".pgm"}
 validVideoFormats = {"avi", "mp4", "mov", "mpg"}
 webValidVideoFormats = {"mp4"}
+
 
 # Ad hoc way to guess the FPS of an Image Sequence based on file names
 # Currently not being used, can only be used once you know that all items

--- a/server/viame_server/utils.py
+++ b/server/viame_server/utils.py
@@ -2,9 +2,11 @@ from girder.models.item import Item
 from girder.models.folder import Folder
 
 
-validImageFormats = {"png", "jpg", "jpeg", "tif", "tiff", "sgi", ".bmp", ".pgm"}
-validVideoFormats = {"avi", "mp4", "mov", "mpg"}
 webValidVideoFormats = {"mp4"}
+webValidImageFormats = {"png", "jpg", "jpeg"}
+
+validImageFormats = {*webValidImageFormats, "tif", "tiff", "sgi", "bmp", "pgm"}
+validVideoFormats = {*webValidVideoFormats, "avi", "mov", "mpg"}
 
 
 # Ad hoc way to guess the FPS of an Image Sequence based on file names

--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -107,7 +107,7 @@ class Viame(Resource):
         upload_token = self.getCurrentToken()
         convert_images.delay(
             folder["_id"],
-            str(upload_token["_id"]),
+            girder_client_token=str(upload_token["_id"]),
             girder_job_title=f"Converting {folder['_id']} to a web friendly format",
         )
 

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -196,8 +196,8 @@ def convert_images(self, folderId):
             self.job_manager.write(output)
 
             if process.returncode == 0:
-                gc.delete(f"item/{item['_id']}")
                 gc.uploadFileToFolder(folderId, new_item_path)
+                gc.delete(f"item/{item['_id']}")
                 count += 1
 
     return count

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -152,7 +152,7 @@ def convert_video(self, path, folderId, token, auxiliaryFolderId):
 
 
 @app.task(bind=True)
-def convert_images(self, folderId, token):
+def convert_images(self, folderId):
     """
     Ensures that all images in a folder are in a web friendly format (png or jpeg).
 
@@ -162,7 +162,6 @@ def convert_images(self, folderId, token):
     Returns the number of images successfully converted.
     """
     gc = self.girder_client
-    gc.token = token
 
     items = gc.listItem(folderId)
     skip_item = (

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -169,13 +169,13 @@ def convert_images(self, folderId):
         or item["name"].endswith(".jpeg")
         or item["name"].endswith(".jpg")
     )
-    valid_items = [item for item in items if not skip_item(item)]
+    items_to_convert = [item for item in items if not skip_item(item)]
 
     count = 0
     with tempfile.TemporaryDirectory() as temp:
         dest_dir = Path(temp)
 
-        for item in valid_items:
+        for item in items_to_convert:
             # Assumes 1 file per item
             gc.downloadItem(item["_id"], dest_dir, item["name"])
 


### PR DESCRIPTION
Fixes #48.

This exposes an endpoint `/viame/image_conversion`, that will convert all images within the specified folder to a web friendly format (currently `.png`, but we might want to change that to `.jpg` for saved bandwidth.

One thing this does is replaces the files in the specified folder with the converted files, if the conversion succeeds. We could do this immutably, but I wasn't sure if that was desired, so I didn't initially include it. 

This is also hooked up to the front-end, so when uploading files, it will call that endpoint if there are any files that have image formats which need conversion.

One thing that might be helpful to sync the frontend and backend is an endpoint on the backend that returns the valid image/video formats. If we think this is a good idea we can make a separate issue for it.

Also commit 39754fd should be ignored, as it's just a formatting change.