### PR TITLE
91 pyproject black isort

### DIFF
--- a/server/dev-requirements.txt
+++ b/server/dev-requirements.txt
@@ -1,0 +1,3 @@
+black
+flake8
+isort

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.black]
+line-length = 80
+skip-string-normalization = true
+target-version = ['py37']
+exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|venv'
+
+[tool.isort]
+line_length = 80
+use_parentheses = true
+include_trailing_comma = true
+multi_line_output = 3
+skip = "venv/**/*"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.black]
-line-length = 80
+line-length = 88
 skip-string-normalization = true
 target-version = ['py37']
 exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|venv'
 
 [tool.isort]
-line_length = 80
+line_length = 88
 use_parentheses = true
 include_trailing_comma = true
 multi_line_output = 3

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 requirements = [
     "girder==3.1.0",

--- a/server/viame_server/__init__.py
+++ b/server/viame_server/__init__.py
@@ -57,9 +57,7 @@ class GirderPlugin(plugin.GirderPlugin):
             check_existing_annotations,
         )
         events.bind(
-            "model.upload.finalize",
-            "fileUpload",
-            maybe_mark_folder_for_annotation,
+            "model.upload.finalize", "fileUpload", maybe_mark_folder_for_annotation,
         )
 
         # Create dependency on worker

--- a/server/viame_server/__init__.py
+++ b/server/viame_server/__init__.py
@@ -1,18 +1,17 @@
 import os
-import sys
 import re
-from pathlib import Path
+import sys
 from os import getenv
+from pathlib import Path
 
 from girder import events, plugin
 from girder.models.setting import Setting
 from girder_worker.girder_plugin import WorkerPlugin
 
 from .client_webroot import ClientWebroot
+from .event import check_existing_annotations, maybe_mark_folder_for_annotation
 from .viame import Viame
 from .viame_detection import ViameDetection
-from .event import check_existing_annotations, maybe_mark_folder_for_annotation
-
 
 env_pipelines_path = getenv("VIAME_PIPELINES_PATH")
 
@@ -42,7 +41,7 @@ def load_pipelines():
 
 class GirderPlugin(plugin.GirderPlugin):
     def load(self, info):
-        
+
         info["apiRoot"].viame = Viame(pipelines=load_pipelines())
         info["apiRoot"].viame_detection = ViameDetection()
         # Relocate Girder
@@ -58,12 +57,22 @@ class GirderPlugin(plugin.GirderPlugin):
             check_existing_annotations,
         )
         events.bind(
-            "model.upload.finalize", "fileUpload", maybe_mark_folder_for_annotation
+            "model.upload.finalize",
+            "fileUpload",
+            maybe_mark_folder_for_annotation,
         )
 
         # Create dependency on worker
         plugin.getPlugin('worker').load(info)
-        Setting().set('worker.api_url', os.environ.get('WORKER_API_URL', 'http://girder:8080/api/v1'))
-        Setting().set('worker.broker', os.environ.get('WORKER_BROKER', 'amqp://guest:guest@rabbit/'))
-        Setting().set('worker.backend', os.environ.get('WORKER_BACKEND', 'amqp://guest:guest@rabbit/'))
-
+        Setting().set(
+            'worker.api_url',
+            os.environ.get('WORKER_API_URL', 'http://girder:8080/api/v1'),
+        )
+        Setting().set(
+            'worker.broker',
+            os.environ.get('WORKER_BROKER', 'amqp://guest:guest@rabbit/'),
+        )
+        Setting().set(
+            'worker.backend',
+            os.environ.get('WORKER_BACKEND', 'amqp://guest:guest@rabbit/'),
+        )

--- a/server/viame_server/client_webroot.py
+++ b/server/viame_server/client_webroot.py
@@ -14,9 +14,7 @@ class ClientWebroot(WebrootBase):
         }
 
     def GET(self, **params):
-        file = open(
-            os.path.join(constants.STATIC_ROOT_DIR, "viame", "index.html"), "r"
-        )
+        file = open(os.path.join(constants.STATIC_ROOT_DIR, "viame", "index.html"), "r")
         return file.read()
 
     def DELETE(self, **params):

--- a/server/viame_server/client_webroot.py
+++ b/server/viame_server/client_webroot.py
@@ -1,6 +1,7 @@
 import os
-from girder.utility.webroot import WebrootBase
+
 from girder import constants
+from girder.utility.webroot import WebrootBase
 
 
 class ClientWebroot(WebrootBase):
@@ -13,7 +14,9 @@ class ClientWebroot(WebrootBase):
         }
 
     def GET(self, **params):
-        file = open(os.path.join(constants.STATIC_ROOT_DIR, "viame", "index.html"), "r")
+        file = open(
+            os.path.join(constants.STATIC_ROOT_DIR, "viame", "index.html"), "r"
+        )
         return file.read()
 
     def DELETE(self, **params):

--- a/server/viame_server/event.py
+++ b/server/viame_server/event.py
@@ -15,9 +15,7 @@ def check_existing_annotations(event):
         folder = Folder().findOne({"_id": item["folderId"]})
 
         # FPS is hardcoded for now
-        folder["meta"].update(
-            {"type": "image-sequence", "viame": True, "fps": 30}
-        )
+        folder["meta"].update({"type": "image-sequence", "viame": True, "fps": 30})
         Folder().save(folder)
 
 
@@ -30,9 +28,7 @@ def maybe_mark_folder_for_annotation(event):
     parent = Folder().findOne({"_id": info["parentId"]})
 
     fileType = info["mimeType"].split("/")[-1]
-    validFileType = (
-        fileType in validImageFormats or fileType in validVideoFormats
-    )
+    validFileType = fileType in validImageFormats or fileType in validVideoFormats
 
     if validFileType and parent["meta"].get("viame"):
         parent["meta"]["annotate"] = True

--- a/server/viame_server/event.py
+++ b/server/viame_server/event.py
@@ -15,7 +15,9 @@ def check_existing_annotations(event):
         folder = Folder().findOne({"_id": item["folderId"]})
 
         # FPS is hardcoded for now
-        folder["meta"].update({"type": "image-sequence", "viame": True, "fps": 30})
+        folder["meta"].update(
+            {"type": "image-sequence", "viame": True, "fps": 30}
+        )
         Folder().save(folder)
 
 
@@ -28,7 +30,9 @@ def maybe_mark_folder_for_annotation(event):
     parent = Folder().findOne({"_id": info["parentId"]})
 
     fileType = info["mimeType"].split("/")[-1]
-    validFileType = fileType in validImageFormats or fileType in validVideoFormats
+    validFileType = (
+        fileType in validImageFormats or fileType in validVideoFormats
+    )
 
     if validFileType and parent["meta"].get("viame"):
         parent["meta"]["annotate"] = True

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -25,9 +25,7 @@ def parse(file):
         .decode("utf-8")
         .split("\n")
     )
-    reader = csv.reader(
-        row for row in rows if (not row.startswith("#") and row)
-    )
+    reader = csv.reader(row for row in rows if (not row.startswith("#") and row))
     detections = []
     for row in reader:
         features = {}
@@ -61,20 +59,13 @@ def parse(file):
             {
                 "track": int(row[0]),
                 "frame": int(row[2]),
-                "bounds": [
-                    float(row[3]),
-                    float(row[5]),
-                    float(row[4]),
-                    float(row[6]),
-                ],
+                "bounds": [float(row[3]), float(row[5]), float(row[4]), float(row[6]),],
                 "confidence": float(row[7]),
                 "fishLength": float(row[8]),
                 "confidencePairs": [],
                 "features": {},
                 "attributes": attributes if attributes else None,
-                "trackAttributes": track_attributes
-                if track_attributes
-                else None,
+                "trackAttributes": track_attributes if track_attributes else None,
             }
         )
     return detections

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -1,0 +1,80 @@
+"""
+VIAME Fish format deserializer
+"""
+import csv
+import re
+
+from girder.models.file import File
+
+
+def _deduceType(value):
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    try:
+        number = float(value)
+        return number
+    except ValueError:
+        return value
+
+
+def parse(file):
+    rows = (
+        b"".join(list(File().download(file, headers=False)()))
+        .decode("utf-8")
+        .split("\n")
+    )
+    reader = csv.reader(
+        row for row in rows if (not row.startswith("#") and row)
+    )
+    detections = []
+    for row in reader:
+        features = {}
+        attributes = {}
+        track_attributes = {}
+
+        confidence_pairs = [
+            [row[i], float(row[i + 1])]
+            for i in range(9, len(row), 2)
+            if not row[i].startswith("(")
+        ]
+        start = len(row) - 1 if len(row) % 2 == 0 else len(row) - 2
+
+        for j in range(start, len(row)):
+            if row[j].startswith("(kp)"):
+                if "head" in row[j]:
+                    groups = re.match(r"\(kp\) head ([0-9]+) ([0-9]+)", row[j])
+                    if groups:
+                        features["head"] = (groups[1], groups[2])
+                elif "tail" in row[j]:
+                    groups = re.match(r"\(kp\) tail ([0-9]+) ([0-9]+)", row[j])
+                    if groups:
+                        features["tail"] = (groups[1], groups[2])
+            if row[j].startswith("(atr)"):
+                groups = re.match(r"\(atr\) (.+) (.+)", row[j])
+                attributes[groups[1]] = _deduceType(groups[2])
+            if row[j].startswith("(trk-atr)"):
+                groups = re.match(r"\(trk-atr\) (.+) (.+)", row[j])
+                track_attributes[groups[1]] = _deduceType(groups[2])
+        detections.append(
+            {
+                "track": int(row[0]),
+                "frame": int(row[2]),
+                "bounds": [
+                    float(row[3]),
+                    float(row[5]),
+                    float(row[4]),
+                    float(row[6]),
+                ],
+                "confidence": float(row[7]),
+                "fishLength": float(row[8]),
+                "confidencePairs": [],
+                "features": {},
+                "attributes": attributes if attributes else None,
+                "trackAttributes": track_attributes
+                if track_attributes
+                else None,
+            }
+        )
+    return detections

--- a/server/viame_server/transforms.py
+++ b/server/viame_server/transforms.py
@@ -75,12 +75,7 @@ class GirderUploadToFolder(GirderClientResultTransform):
     """
 
     def __init__(
-        self,
-        _id,
-        metadata=None,
-        delete_file=False,
-        upload_kwargs=None,
-        **kwargs,
+        self, _id, metadata=None, delete_file=False, upload_kwargs=None, **kwargs,
     ):
         super(GirderUploadToFolder, self).__init__(**kwargs)
         self.folder_id = _id

--- a/server/viame_server/transforms.py
+++ b/server/viame_server/transforms.py
@@ -3,8 +3,8 @@ import shutil
 import tempfile
 
 from girder_worker_utils.transforms.girder_io import (
-    GirderClientTransform,
     GirderClientResultTransform,
+    GirderClientTransform,
 )
 
 
@@ -59,8 +59,7 @@ class GetPathFromFolderId(GirderClientTransform):
         return self.folder_path
 
     def cleanup(self):
-        shutil.rmtree(os.path.dirname(self.folder_path),
-                      ignore_errors=True)
+        shutil.rmtree(os.path.dirname(self.folder_path), ignore_errors=True)
 
 
 class GirderUploadToFolder(GirderClientResultTransform):
@@ -76,7 +75,12 @@ class GirderUploadToFolder(GirderClientResultTransform):
     """
 
     def __init__(
-        self, _id, metadata=None, delete_file=False, upload_kwargs=None, **kwargs
+        self,
+        _id,
+        metadata=None,
+        delete_file=False,
+        upload_kwargs=None,
+        **kwargs,
     ):
         super(GirderUploadToFolder, self).__init__(**kwargs)
         self.folder_id = _id

--- a/server/viame_server/utils.py
+++ b/server/viame_server/utils.py
@@ -39,9 +39,7 @@ def determine_image_sequence_fps(folder):
 
 
 def get_or_create_auxiliary_folder(folder, user):
-    return Folder().createFolder(
-        folder, "auxiliary", reuseExisting=True, creator=user
-    )
+    return Folder().createFolder(folder, "auxiliary", reuseExisting=True, creator=user)
 
 
 def move_existing_result_to_auxiliary_folder(folder, user):

--- a/server/viame_server/utils.py
+++ b/server/viame_server/utils.py
@@ -1,6 +1,5 @@
-from girder.models.item import Item
 from girder.models.folder import Folder
-
+from girder.models.item import Item
 
 validImageFormats = {"png", "jpg", "jpeg"}
 validVideoFormats = {"avi", "mp4", "mov", "mpg"}
@@ -37,7 +36,9 @@ def determine_image_sequence_fps(folder):
 
 
 def get_or_create_auxiliary_folder(folder, user):
-    return Folder().createFolder(folder, "auxiliary", reuseExisting=True, creator=user)
+    return Folder().createFolder(
+        folder, "auxiliary", reuseExisting=True, creator=user
+    )
 
 
 def move_existing_result_to_auxiliary_folder(folder, user):

--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -1,13 +1,18 @@
 from girder.api import access
-from girder.constants import AccessType
 from girder.api.describe import Description, autoDescribeRoute, describeRoute
 from girder.api.rest import Resource
+from girder.constants import AccessType
 from girder.models.folder import Folder
 from girder.models.item import Item
-from viame_tasks.tasks import run_pipeline, convert_video
 
-from .transforms import GetPathFromItemId, GetPathFromFolderId, GirderUploadToFolder
+from viame_tasks.tasks import convert_video, run_pipeline
+
 from .model.attribute import Attribute
+from .transforms import (
+    GetPathFromFolderId,
+    GetPathFromItemId,
+    GirderUploadToFolder,
+)
 from .utils import (
     get_or_create_auxiliary_folder,
     move_existing_result_to_auxiliary_folder,
@@ -54,14 +59,21 @@ class Viame(Resource):
         user = self.getCurrentUser()
         move_existing_result_to_auxiliary_folder(folder, user)
         input_type = folder["meta"]["type"]
-        result_metadata = { "detection": str(folder["_id"]), "pipeline": pipeline }
+        result_metadata = {
+            "detection": str(folder["_id"]),
+            "pipeline": pipeline,
+        }
         return run_pipeline.delay(
             GetPathFromFolderId(str(folder["_id"])),
             pipeline,
             input_type,
-            girder_job_title=("Running {} on {}".format(pipeline, str(folder["name"]))),
+            girder_job_title=(
+                "Running {} on {}".format(pipeline, str(folder["name"]))
+            ),
             girder_result_hooks=[
-                GirderUploadToFolder(str(folder["_id"]), result_metadata, delete_file=True)
+                GirderUploadToFolder(
+                    str(folder["_id"]), result_metadata, delete_file=True
+                )
             ],
         )
 
@@ -87,13 +99,17 @@ class Viame(Resource):
             str(upload_token["_id"]),
             auxiliary["_id"],
             girder_job_title=(
-                "Converting {} to a web friendly format".format(str(item["_id"]))
+                "Converting {} to a web friendly format".format(
+                    str(item["_id"])
+                )
             ),
         )
 
     @access.user
     @autoDescribeRoute(
-        Description("").jsonParam("data", "", requireObject=True, paramType="body")
+        Description("").jsonParam(
+            "data", "", requireObject=True, paramType="body"
+        )
     )
     def create_attribute(self, data, params):
         attribute = Attribute().create(
@@ -119,6 +135,8 @@ class Viame(Resource):
         return Attribute().save(attribute)
 
     @access.user
-    @autoDescribeRoute(Description("").modelParam("id", model=Attribute, required=True))
+    @autoDescribeRoute(
+        Description("").modelParam("id", model=Attribute, required=True)
+    )
     def delete_attribute(self, attribute, params):
         return Attribute().remove(attribute)

--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -4,9 +4,8 @@ from girder.api.rest import Resource
 from girder.constants import AccessType
 from girder.models.folder import Folder
 from girder.models.item import Item
-from viame_tasks.tasks import run_pipeline, convert_video, convert_images
 
-from viame_tasks.tasks import convert_video, run_pipeline
+from viame_tasks.tasks import convert_images, convert_video, run_pipeline
 
 from .model.attribute import Attribute
 from .transforms import (
@@ -109,7 +108,9 @@ class Viame(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("Convert a folder of images into a web friendly format").modelParam(
+        Description(
+            "Convert a folder of images into a web friendly format"
+        ).modelParam(
             "folder",
             description="Folder containing the images to convert",
             model=Folder,
@@ -128,7 +129,9 @@ class Viame(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("").jsonParam("data", "", requireObject=True, paramType="body")
+        Description("").jsonParam(
+            "data", "", requireObject=True, paramType="body"
+        )
     )
     def create_attribute(self, data, params):
         attribute = Attribute().create(

--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -68,9 +68,7 @@ class Viame(Resource):
             GetPathFromFolderId(str(folder["_id"])),
             pipeline,
             input_type,
-            girder_job_title=(
-                "Running {} on {}".format(pipeline, str(folder["name"]))
-            ),
+            girder_job_title=("Running {} on {}".format(pipeline, str(folder["name"]))),
             girder_result_hooks=[
                 GirderUploadToFolder(
                     str(folder["_id"]), result_metadata, delete_file=True
@@ -100,17 +98,13 @@ class Viame(Resource):
             str(upload_token["_id"]),
             auxiliary["_id"],
             girder_job_title=(
-                "Converting {} to a web friendly format".format(
-                    str(item["_id"])
-                )
+                "Converting {} to a web friendly format".format(str(item["_id"]))
             ),
         )
 
     @access.user
     @autoDescribeRoute(
-        Description(
-            "Convert a folder of images into a web friendly format"
-        ).modelParam(
+        Description("Convert a folder of images into a web friendly format").modelParam(
             "folder",
             description="Folder containing the images to convert",
             model=Folder,
@@ -129,9 +123,7 @@ class Viame(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("").jsonParam(
-            "data", "", requireObject=True, paramType="body"
-        )
+        Description("").jsonParam("data", "", requireObject=True, paramType="body")
     )
     def create_attribute(self, data, params):
         attribute = Attribute().create(
@@ -157,8 +149,6 @@ class Viame(Resource):
         return Attribute().save(attribute)
 
     @access.user
-    @autoDescribeRoute(
-        Description("").modelParam("id", model=Attribute, required=True)
-    )
+    @autoDescribeRoute(Description("").modelParam("id", model=Attribute, required=True))
     def delete_attribute(self, attribute, params):
         return Attribute().remove(attribute)

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -42,8 +42,7 @@ class ViameDetection(Resource):
     def get_detection(self, folder):
         detectionItems = list(
             Item().findWithPermissions(
-                {"meta.detection": str(folder["_id"])},
-                user=self.getCurrentUser(),
+                {"meta.detection": str(folder["_id"])}, user=self.getCurrentUser(),
             )
         )
         detectionItems.sort(key=lambda d: d["created"], reverse=True)
@@ -65,9 +64,7 @@ class ViameDetection(Resource):
     )
     def get_clip_meta(self, folder):
         detections = list(
-            Item()
-            .find({"meta.detection": str(folder["_id"])})
-            .sort([("created", -1)])
+            Item().find({"meta.detection": str(folder["_id"])}).sort([("created", -1)])
         )
         detection = detections[0] if len(detections) else None
 
@@ -129,19 +126,13 @@ class ViameDetection(Resource):
                 columns += [key, confidence]
             if d["features"]:
                 for [key, values] in d["features"].items():
-                    columns.append(
-                        "(kp) {} {} {}".format(key, values[0], values[1])
-                    )
+                    columns.append("(kp) {} {} {}".format(key, values[0], values[1]))
             if d["attributes"]:
                 for [key, value] in d["attributes"].items():
-                    columns.append(
-                        "(atr) {} {}".format(key, valueToString(value))
-                    )
+                    columns.append("(atr) {} {}".format(key, valueToString(value)))
             if trackAttributes:
                 for [key, value] in trackAttributes.items():
-                    columns.append(
-                        "(trk-atr) {} {}".format(key, valueToString(value))
-                    )
+                    columns.append("(trk-atr) {} {}".format(key, valueToString(value)))
             return columns
 
         detections.sort(key=lambda d: d["track"])
@@ -165,9 +156,7 @@ class ViameDetection(Resource):
         move_existing_result_to_auxiliary_folder(folder, user)
 
         timestamp = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
-        newResultItem = Item().createItem(
-            "result_" + timestamp + ".csv", user, folder
-        )
+        newResultItem = Item().createItem("result_" + timestamp + ".csv", user, folder)
         Item().setMetadata(
             newResultItem, {"detection": str(folder["_id"])}, allowNull=True,
         )

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -1,18 +1,23 @@
 import csv
-from datetime import datetime
 import io
 import re
+from datetime import datetime
 
 from girder.api import access
-from girder.constants import AccessType
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
-from girder.models.item import Item
-from girder.models.folder import Folder
-from girder.models.upload import Upload
+from girder.constants import AccessType
 from girder.models.file import File
+from girder.models.folder import Folder
+from girder.models.item import Item
+from girder.models.upload import Upload
 
-from .utils import move_existing_result_to_auxiliary_folder, validVideoFormats, webValidVideoFormats
+from viame_server.serializers import viame
+from viame_server.utils import (
+    move_existing_result_to_auxiliary_folder,
+    validVideoFormats,
+    webValidVideoFormats,
+)
 
 
 class ViameDetection(Resource):
@@ -37,67 +42,15 @@ class ViameDetection(Resource):
     def get_detection(self, folder):
         detectionItems = list(
             Item().findWithPermissions(
-                {"meta.detection": str(folder["_id"])}, user=self.getCurrentUser(),
+                {"meta.detection": str(folder["_id"])},
+                user=self.getCurrentUser(),
             )
         )
         detectionItems.sort(key=lambda d: d["created"], reverse=True)
         if not len(detectionItems):
             return None
         file = Item().childFiles(detectionItems[0])[0]
-        rows = (
-            b"".join(list(File().download(file, headers=False)()))
-            .decode("utf-8")
-            .split("\n")
-        )
-        reader = csv.reader(row for row in rows if (not row.startswith("#") and row))
-        detections = []
-        for row in reader:
-            features = {}
-            attributes = {}
-            track_attributes = {}
-
-            confidence_pairs = [
-                [row[i], float(row[i + 1])]
-                for i in range(9, len(row), 2)
-                if not row[i].startswith("(")
-            ]
-            start = len(row) - 1 if len(row) % 2 == 0 else len(row) - 2
-
-            for j in range(start, len(row)):
-                if row[j].startswith("(kp)"):
-                    if "head" in row[j]:
-                        groups = re.match(r"\(kp\) head ([0-9]+) ([0-9]+)", row[j])
-                        if groups:
-                            features["head"] = (groups[1], groups[2])
-                    elif "tail" in row[j]:
-                        groups = re.match(r"\(kp\) tail ([0-9]+) ([0-9]+)", row[j])
-                        if groups:
-                            features["tail"] = (groups[1], groups[2])
-                if row[j].startswith("(atr)"):
-                    groups = re.match(r"\(atr\) (.+) (.+)", row[j])
-                    attributes[groups[1]] = deduceType(groups[2])
-                if row[j].startswith("(trk-atr)"):
-                    groups = re.match(r"\(trk-atr\) (.+) (.+)", row[j])
-                    track_attributes[groups[1]] = deduceType(groups[2])
-            detections.append(
-                {
-                    "track": int(row[0]),
-                    "frame": int(row[2]),
-                    "bounds": [
-                        float(row[3]),
-                        float(row[5]),
-                        float(row[4]),
-                        float(row[6]),
-                    ],
-                    "confidence": float(row[7]),
-                    "fishLength": float(row[8]),
-                    "confidencePairs": confidence_pairs,
-                    "features": features,
-                    "attributes": attributes if attributes else None,
-                    "trackAttributes": track_attributes if track_attributes else None,
-                }
-            )
-        return detections
+        return viame.parse(file)
 
     @access.user
     @autoDescribeRoute(
@@ -112,7 +65,9 @@ class ViameDetection(Resource):
     )
     def get_clip_meta(self, folder):
         detections = list(
-            Item().find({"meta.detection": str(folder["_id"])}).sort([("created", -1)])
+            Item()
+            .find({"meta.detection": str(folder["_id"])})
+            .sort([("created", -1)])
         )
         detection = detections[0] if len(detections) else None
 
@@ -174,13 +129,19 @@ class ViameDetection(Resource):
                 columns += [key, confidence]
             if d["features"]:
                 for [key, values] in d["features"].items():
-                    columns.append("(kp) {} {} {}".format(key, values[0], values[1]))
+                    columns.append(
+                        "(kp) {} {} {}".format(key, values[0], values[1])
+                    )
             if d["attributes"]:
                 for [key, value] in d["attributes"].items():
-                    columns.append("(atr) {} {}".format(key, valueToString(value)))
+                    columns.append(
+                        "(atr) {} {}".format(key, valueToString(value))
+                    )
             if trackAttributes:
                 for [key, value] in trackAttributes.items():
-                    columns.append("(trk-atr) {} {}".format(key, valueToString(value)))
+                    columns.append(
+                        "(trk-atr) {} {}".format(key, valueToString(value))
+                    )
             return columns
 
         detections.sort(key=lambda d: d["track"])
@@ -204,7 +165,9 @@ class ViameDetection(Resource):
         move_existing_result_to_auxiliary_folder(folder, user)
 
         timestamp = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
-        newResultItem = Item().createItem("result_" + timestamp + ".csv", user, folder)
+        newResultItem = Item().createItem(
+            "result_" + timestamp + ".csv", user, folder
+        )
         Item().setMetadata(
             newResultItem, {"detection": str(folder["_id"])}, allowNull=True,
         )
@@ -219,15 +182,3 @@ class ViameDetection(Resource):
             user=user,
         )
         return True
-
-
-def deduceType(value):
-    if value == "true":
-        return True
-    if value == "false":
-        return False
-    try:
-        number = float(value)
-        return number
-    except ValueError:
-        return value

--- a/server/viame_tasks/__init__.py
+++ b/server/viame_tasks/__init__.py
@@ -1,4 +1,5 @@
 import logging
+
 from girder_worker import GirderWorkerPluginABC
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -81,9 +81,7 @@ def run_pipeline(self, input_path, pipeline, input_type):
 
     cmd = " ".join(command)
     print('Running command:', cmd)
-    process = Popen(
-        cmd, stderr=PIPE, stdout=PIPE, shell=True, executable='/bin/bash'
-    )
+    process = Popen(cmd, stderr=PIPE, stdout=PIPE, shell=True, executable='/bin/bash')
     stdout, stderr = process.communicate()
     if process.returncode > 0:
         raise RuntimeError(
@@ -133,9 +131,7 @@ def convert_video(self, path, folderId, token, auxiliaryFolderId):
         filter(lambda x: x["codec_type"] == "video", jsoninfo["streams"])
     )
     if len(videostream) != 1:
-        raise Exception(
-            'Expected 1 video stream, found {}'.format(len(videostream))
-        )
+        raise Exception('Expected 1 video stream, found {}'.format(len(videostream)))
 
     self.girder_client.addMetadataToFolder(
         folderId,
@@ -202,14 +198,10 @@ def convert_images(self, folderId):
             gc.downloadItem(item["_id"], dest_dir, item["name"])
 
             item_path = dest_dir / item["name"]
-            new_item_path = dest_dir / ".".join(
-                [*item["name"].split(".")[:-1], "png"]
-            )
+            new_item_path = dest_dir / ".".join([*item["name"].split(".")[:-1], "png"])
 
             process = Popen(
-                ["ffmpeg", "-i", item_path, new_item_path],
-                stdout=PIPE,
-                stderr=PIPE,
+                ["ffmpeg", "-i", item_path, new_item_path], stdout=PIPE, stderr=PIPE,
             )
             stdout, stderr = process.communicate()
 

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -1,8 +1,8 @@
 import json
 import os
 import tempfile
-from subprocess import Popen, PIPE
 from pathlib import Path
+from subprocess import PIPE, Popen
 
 from girder_worker.app import app
 
@@ -202,10 +202,14 @@ def convert_images(self, folderId):
             gc.downloadItem(item["_id"], dest_dir, item["name"])
 
             item_path = dest_dir / item["name"]
-            new_item_path = dest_dir / ".".join([*item["name"].split(".")[:-1], "png"])
+            new_item_path = dest_dir / ".".join(
+                [*item["name"].split(".")[:-1], "png"]
+            )
 
             process = Popen(
-                ["ffmpeg", "-i", item_path, new_item_path], stdout=PIPE, stderr=PIPE
+                ["ffmpeg", "-i", item_path, new_item_path],
+                stdout=PIPE,
+                stderr=PIPE,
             )
             stdout, stderr = process.communicate()
 


### PR DESCRIPTION
Adds `black` and `isort`

The VS Code config to run both of these on save is:

```
{
  "python.formatting.provider": "black",
  "[python]": {
    "editor.formatOnSave": true,
    "editor.codeActionsOnSave": {
      "source.organizeImports": true
    }
  },
}
```

I also factored the parsing logic out into a serializers subfolder in preparation of #96 and other formats.  I don't think it's great style to do that all in the REST handler anyway.

FWIW, I think 80 char columns is too restrictive.  I prefer 90-100 myself, but ya'll should decide.

resolves #91 