### PR TITLE
Fixes Persistent text issues

### DIFF
--- a/client/src/components/layers/MarkerLayer.vue
+++ b/client/src/components/layers/MarkerLayer.vue
@@ -48,6 +48,10 @@ export default {
     this.frameChanged();
     this.updateStyle();
   },
+  beforeDestroy() {
+    this.pointFeature.data([]).draw();
+    this.annotator.geoViewer.removeChild(this.featureLayer);
+  },
   methods: {
     frameChanged() {
       const frame = this.annotator.syncedFrame;

--- a/client/src/components/layers/TextLayer.vue
+++ b/client/src/components/layers/TextLayer.vue
@@ -51,6 +51,10 @@ export default {
     this.frameChanged();
     this.updateStyle();
   },
+  beforeDestroy() {
+    this.textFeature.data([]).draw();
+    this.annotator.geoViewer.removeChild(this.featureLayer);
+  },
   methods: {
     frameChanged() {
       const frame = this.annotator.syncedFrame;


### PR DESCRIPTION
The `TextLayer.vue` has a `v-if` tied to the length of the data it receives.  If the data is 0 it won't render.  The Data is also connected to a property which is used inside of `TextLayer.vue` to compute the `frameMap` used to render the page.  When data hits zero it will stop rendering the Vue element but keep the computed data property.  So the GeoJS render still believes that there is text data to display.  I added in a proper Destroy binding as well as removing the `featureLayer` and drawing the screen blank before. I followed a similar beforeDestroy used on the main `AnnotationLayer.vue` and the `EditAnnotationLayer.vue`
![image](https://user-images.githubusercontent.com/61746913/81449281-ea70ed00-914d-11ea-9025-89d1d73085bc.png)

`MarkerLayer.vue` had the same issue so I added the fix to it as well.