### PR TITLE
Fix #110

### DIFF
--- a/client/src/use/useGirderDataset.js
+++ b/client/src/use/useGirderDataset.js
@@ -40,20 +40,12 @@ export default function useGirderDataset() {
           params: { folderId: _dataset._id },
         },
       );
-      if (!clipMeta.video) {
+      if (!clipMeta.videoUrl) {
         // TODO: better error handling
-        return;
+        throw new Error('Expected clip_meta.video, but was empty.');
       }
-      const { data: files } = await girderRest.get(
-        `item/${clipMeta.video._id}/files`,
-      );
-      if (files.length < 1) {
-        // TODO: better error handling
-        return;
-      }
-      videoUrl.value = `api/v1/file/${files[0]._id}/download`;
-      return;
-    } if (_dataset.meta.type === ImageSequenceType) {
+      videoUrl.value = clipMeta.videoUrl;
+    } else if (_dataset.meta.type === ImageSequenceType) {
       // Image Sequence type annotator
       const { data: items } = await girderRest.get('item', {
         // TODO: what if there are more than 200K?
@@ -69,9 +61,9 @@ export default function useGirderDataset() {
           );
         })
         .map((item) => `api/v1/item/${item._id}/download`);
-      return;
+    } else {
+      throw new Error(`Unable to load media for dataset type: ${_dataset.meta.type}`);
     }
-    throw new Error(`Unknown dataset type: ${_dataset.meta.type}`);
   });
 
   async function loadDataset(datasetId) {

--- a/server/README.md
+++ b/server/README.md
@@ -9,7 +9,6 @@ Image chips that compose a video are stored as girder items in a folder.  Videos
   "annotate": true,
   "fps": <number>,
   "type": "image-sequence" | "video",
-  "viame": true,
 }
 ```
 

--- a/server/viame_server/utils.py
+++ b/server/viame_server/utils.py
@@ -1,11 +1,10 @@
 from girder.models.folder import Folder
 from girder.models.item import Item
 
-webValidVideoFormats = {"mp4"}
 webValidImageFormats = {"png", "jpg", "jpeg"}
 
 validImageFormats = {*webValidImageFormats, "tif", "tiff", "sgi", "bmp", "pgm"}
-validVideoFormats = {*webValidVideoFormats, "avi", "mov", "mpg"}
+validVideoFormats = {"mp4", "avi", "mov", "mpg"}
 
 
 # Ad hoc way to guess the FPS of an Image Sequence based on file names
@@ -50,3 +49,7 @@ def move_existing_result_to_auxiliary_folder(folder, user):
     )
     if existingResultItem:
         Item().move(existingResultItem, auxiliary)
+
+
+def itemIsWebsafeVideo(item: Item) -> bool:
+    return item.get("meta", {}).get("codec") == "h264"

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -155,7 +155,7 @@ def convert_video(self, path, folderId, token, auxiliaryFolderId):
     self.job_manager.write(output)
     new_file = self.girder_client.uploadFileToFolder(folderId, output_path)
     self.girder_client.addMetadataToItem(
-        new_file['itemId'], {"folderId": folderId, "codec": "h264",},
+        new_file['itemId'], {"codec": "h264",},
     )
     self.girder_client.addMetadataToFolder(
         folderId,


### PR DESCRIPTION
This turned out to touch a lot of things.

## Changes

* Cannot use `.mp4` to check for valid video.   Modify `maybe_mark_...` to ignore video uploads, removed `webValidVideoFormats` const.
* Use codec metadata on video item to signal web safety
* Return resource URL directly, simplify client code
* **remove `viame` metadata tag**: it wasn't being used by anything, so I removed it.


fixes #110