### PR TITLE
Server-side JSON track processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ devel/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/client/src/use/useDetections.js
+++ b/client/src/use/useDetections.js
@@ -7,7 +7,10 @@ export default function useDetections({ markChangesPending }) {
 
   async function loadDetections(datasetFolderId) {
     const { data } = await girderRest.get('viame_detection', {
-      params: { folderId: datasetFolderId },
+      params: {
+        folderId: datasetFolderId,
+        formatting: 'detection_json',
+      },
     });
     detections.value = data
       ? data.map((detection) => Object.freeze(detection))

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -19,6 +19,33 @@ def _deduceType(value):
         return value
 
 
+def process_row(row, features, attributes, track_attributes):
+    confidence_pairs = [
+        [row[i], float(row[i + 1])]
+        for i in range(9, len(row), 2)
+        if not row[i].startswith("(")
+    ]
+    start = len(row) - 1 if len(row) % 2 == 0 else len(row) - 2
+
+    for j in range(start, len(row)):
+        if row[j].startswith("(kp)"):
+            if "head" in row[j]:
+                groups = re.match(r"\(kp\) head ([0-9]+) ([0-9]+)", row[j])
+                if groups:
+                    features["head"] = (groups[1], groups[2])
+            elif "tail" in row[j]:
+                groups = re.match(r"\(kp\) tail ([0-9]+) ([0-9]+)", row[j])
+                if groups:
+                    features["tail"] = (groups[1], groups[2])
+        if row[j].startswith("(atr)"):
+            groups = re.match(r"\(atr\) (.+) (.+)", row[j])
+            attributes[groups[1]] = _deduceType(groups[2])
+        if row[j].startswith("(trk-atr)"):
+            groups = re.match(r"\(trk-atr\) (.+) (.+)", row[j])
+            track_attributes[groups[1]] = _deduceType(groups[2])
+    return confidence_pairs
+
+
 def parse(file):
     rows = (
         b"".join(list(File().download(file, headers=False)()))
@@ -29,32 +56,9 @@ def parse(file):
     detections = []
     for row in reader:
         features = {}
-        attributes = {}
         track_attributes = {}
-
-        confidence_pairs = [
-            [row[i], float(row[i + 1])]
-            for i in range(9, len(row), 2)
-            if not row[i].startswith("(")
-        ]
-        start = len(row) - 1 if len(row) % 2 == 0 else len(row) - 2
-
-        for j in range(start, len(row)):
-            if row[j].startswith("(kp)"):
-                if "head" in row[j]:
-                    groups = re.match(r"\(kp\) head ([0-9]+) ([0-9]+)", row[j])
-                    if groups:
-                        features["head"] = (groups[1], groups[2])
-                elif "tail" in row[j]:
-                    groups = re.match(r"\(kp\) tail ([0-9]+) ([0-9]+)", row[j])
-                    if groups:
-                        features["tail"] = (groups[1], groups[2])
-            if row[j].startswith("(atr)"):
-                groups = re.match(r"\(atr\) (.+) (.+)", row[j])
-                attributes[groups[1]] = _deduceType(groups[2])
-            if row[j].startswith("(trk-atr)"):
-                groups = re.match(r"\(trk-atr\) (.+) (.+)", row[j])
-                track_attributes[groups[1]] = _deduceType(groups[2])
+        attributes = {}
+        confidence_pairs = process_row(row, features, attributes, track_attributes)
         detections.append(
             {
                 "track": int(row[0]),
@@ -64,8 +68,74 @@ def parse(file):
                 "fishLength": float(row[8]),
                 "confidencePairs": confidence_pairs,
                 "features": features,
-                "attributes": attributes if attributes else None,
+                "attributes": attributes,
                 "trackAttributes": track_attributes if track_attributes else None,
             }
         )
     return detections
+
+
+def parseTracks(file):
+    """
+    Convert VIAME web CSV to json tracks.
+    Expect detections to be in increasing order (either globally or by track).
+    """
+    rows = (
+        b"".join(list(File().download(file, headers=False)()))
+        .decode("utf-8")
+        .split("\n")
+    )
+    reader = csv.reader(row for row in rows if (not row.startswith("#") and row))
+    tracks = {}
+
+    for row in reader:
+        features = {}
+        track_attributes = {}
+        attributes = {}
+        confidence_pairs = process_row(row, features, attributes, track_attributes)
+        trackid = int(row[0])
+        frame = int(row[2])
+        bounds = [
+            float(row[3]),
+            float(row[5]),
+            float(row[4]),
+            float(row[6]),
+        ]
+        fishLength = float(row[8])
+
+        if trackid not in tracks:
+            # track is defined as follows...
+            tracks[trackid] = {
+                # First frame with a feature
+                "begin": frame,
+                # Last frame with a feature
+                "end": frame,
+                # Unique among tracks in the video
+                "key": trackid,
+                # Array<{{ frame: number, foo: bar, ...}}>
+                "features": [],
+                # Key is an attribute name, val is a float confidence value
+                "confidencePairs": {},
+                # Key is string, value is freeform
+                "attributes": {},
+            }
+        track = tracks[trackid]
+        track["begin"] = min(frame, track["begin"])
+        features["frame"] = frame
+        features["bounds"] = bounds
+        if fishLength > 0:
+            features["fishLength"] = fishLength
+
+        if attributes:
+            features["attributes"] = attributes
+        track["features"].append(features)
+        for (key, val) in track_attributes:
+            track["attributes"][key] = val
+        if frame > track["end"]:
+            track["end"] = frame
+            # final confidence pair should be taken as the
+            # pair that applied to the whole track
+            for (key, val) in confidence_pairs:
+                track["confidencePairs"][key] = val
+
+    return tracks

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -114,7 +114,7 @@ class ViameDetection(Resource):
             required=True,
             level=AccessType.READ,
         )
-        .param("formatting", "Format to fetch", default="",)
+        .param("formatting", "Format to fetch", default="track_json",)
     )
     def get_detection(self, folder, formatting):
         detectionItems = list(
@@ -127,9 +127,9 @@ class ViameDetection(Resource):
             return None
         file = Item().childFiles(detectionItems[0])[0]
         if formatting == "track_json":
-            return viame.parseTracks(file)
+            return viame.load_csv_as_tracks(file)
         elif formatting == "detection_json":
-            return viame.parse(file)
+            return viame.load_csv_as_detections(file)
         raise RestException(f"formatting {formatting} is not recognized")
 
     @access.user


### PR DESCRIPTION
Add parameter for server to return JSON list of tracks.   This will support #84, but it's only the first step for that issue.

* It is my intention that the server would eventually save this data straight to a file and serve it to the app, then serialize to the VIAME csv format on demand.
* In order to use this on the client, serialization of this new structure to VIAME csv is still missing.  I think that should be a part of this PR, but I want to get some other eyes on the structure here first.