### PR TITLE
122 sort pipelines

### DIFF
--- a/client/src/components/RunPipelineMenu.vue
+++ b/client/src/components/RunPipelineMenu.vue
@@ -18,7 +18,7 @@ export default {
       );
     },
     pipelinesNotRunnable() {
-      return this.selectedEligibleClips.length < 1 || this.pipelines === null;
+      return this.selectedEligibleClips.length < 1 || Object.keys(this.pipelines).length === 0;
     },
   },
 

--- a/client/src/components/RunPipelineMenu.vue
+++ b/client/src/components/RunPipelineMenu.vue
@@ -18,7 +18,7 @@ export default {
       );
     },
     pipelinesNotRunnable() {
-      return this.selectedEligibleClips.length < 1 || Object.keys(this.pipelines).length === 0;
+      return this.selectedEligibleClips.length < 1 || this.pipelines === null;
     },
   },
 

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -8,7 +8,7 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     location: null,
-    pipelines: [],
+    pipelines: null,
   },
   mutations: {
     setLocation(state, location) {
@@ -20,8 +20,26 @@ export default new Vuex.Store({
   },
   actions: {
     async fetchPipelines({ commit, state }) {
-      if (state.pipelines.length === 0) {
+      if (state.pipelines === null) {
         const { data } = await getPipelineList();
+        Object.keys(data).forEach((key) => {
+          const category = data[key];
+          if (category.pipes.length > 0) {
+            category.pipes.sort((a, b) => {
+              if (a.name && b.name) {
+                const aName = a.name.toUpperCase();
+                const bName = b.name.toUpperCase();
+                if (aName > bName) {
+                  return 1;
+                }
+                if (aName < bName) {
+                  return -1;
+                }
+              }
+              return 0;
+            });
+          }
+        });
         commit('setPipelines', data);
         return data;
       }

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -8,7 +8,7 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     location: null,
-    pipelines: null,
+    pipelines: {},
   },
   mutations: {
     setLocation(state, location) {
@@ -20,15 +20,16 @@ export default new Vuex.Store({
   },
   actions: {
     async fetchPipelines({ commit, state }) {
-      if (state.pipelines === null) {
+      if (Object.keys(state.pipelines).length === 0) {
         const { data } = await getPipelineList();
+        // Sort list of pipelines in each category by name
         Object.keys(data).forEach((key) => {
           const category = data[key];
           if (category.pipes.length > 0) {
             category.pipes.sort((a, b) => {
               if (a.name && b.name) {
-                const aName = a.name.toUpperCase();
-                const bName = b.name.toUpperCase();
+                const aName = a.name.toLowerCase();
+                const bName = b.name.toLowerCase();
                 if (aName > bName) {
                   return 1;
                 }
@@ -40,8 +41,10 @@ export default new Vuex.Store({
             });
           }
         });
-        commit('setPipelines', data);
-        return data;
+        if (data !== null) {
+          commit('setPipelines', data);
+          return data;
+        }
       }
       return state.pipelines;
     },

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -8,7 +8,7 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     location: null,
-    pipelines: {},
+    pipelines: null,
   },
   mutations: {
     setLocation(state, location) {
@@ -20,31 +20,24 @@ export default new Vuex.Store({
   },
   actions: {
     async fetchPipelines({ commit, state }) {
-      if (Object.keys(state.pipelines).length === 0) {
+      if (state.pipelines === null) {
         const { data } = await getPipelineList();
         // Sort list of pipelines in each category by name
-        Object.keys(data).forEach((key) => {
-          const category = data[key];
-          if (category.pipes.length > 0) {
-            category.pipes.sort((a, b) => {
-              if (a.name && b.name) {
-                const aName = a.name.toLowerCase();
-                const bName = b.name.toLowerCase();
-                if (aName > bName) {
-                  return 1;
-                }
-                if (aName < bName) {
-                  return -1;
-                }
-              }
-              return 0;
-            });
-          }
+        Object.values(data).forEach((category) => {
+          category.pipes.sort((a, b) => {
+            const aName = a.name.toLowerCase();
+            const bName = b.name.toLowerCase();
+            if (aName > bName) {
+              return 1;
+            }
+            if (aName < bName) {
+              return -1;
+            }
+            return 0;
+          });
         });
-        if (data !== null) {
-          commit('setPipelines', data);
-          return data;
-        }
+        commit('setPipelines', data);
+        return data;
       }
       return state.pipelines;
     },


### PR DESCRIPTION
Fixes #122 

The previous implementation of pipelines was an empty array (`[]`) by default, that became an object when returned by the axios request.  I switched it to always being an `Object` instead with the default being empty and then sorting before committal.  

The only thing I'm not sure on is if the intended logic for disabling the run pipelines option.  It starts as an array, if you get an error back from axios it doesn't change the result, so the test for `this.pipelines === null` inside of `RunPipeLineMenu.vue` I don't think would ever be reached unless the backend specifically sets the return value to `null`.  
So you would get the ability to open RunPipelines, but have no pipelines available like this: 
![image](https://user-images.githubusercontent.com/61746913/82566743-5ee25d80-9b4a-11ea-9081-b9ad86b50d72.png)

My version prevents the Run Pipelines menu option from being enabled if there is an issue with the request to get the data.  
