### PR TITLE
Various UI Fixes

### DIFF
--- a/client/src/components/Tracks.vue
+++ b/client/src/components/Tracks.vue
@@ -86,11 +86,7 @@ export default {
      */
     scrollPreventDefault(element, keyEvent, direction) {
       if (element === this.$refs.virtualList.$el) {
-        if (direction === 'up') {
-          this.$emit('select-track-up');
-        } else if (direction === 'down') {
-          this.$emit('select-track-down');
-        }
+        this.$emit('select-keyboard-track', direction);
         keyEvent.preventDefault();
       }
     },

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -117,7 +117,11 @@ export default {
         // Prevents advancing the frame while playing if the current image is not loaded
         if (!this.imgs[this.frame].cached || this.loadingVideo) {
           this.frame -= 1; // returns to a loaded image
+          // sync the annotations with the loading frame
+          this.syncedFrame = this.frame;
+          this.emitFrame();
           this.loadingVideo = true;
+
           return;
         }
         this.seek(this.frame);

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -86,7 +86,8 @@ export default {
       const height = this.$refs.workarea.clientHeight || 0;
       // clientWidth and clientHeight are properties used to resize child elements
       this.clientWidth = width;
-      this.clientHeight = height;
+      // Timeline height needs to be offset so it doesn't overlap the frame number
+      this.clientHeight = height - 15;
       const scale = d3
         .scaleLinear()
         .domain([0, this.maxFrame])
@@ -108,7 +109,7 @@ export default {
         .attr('height', height);
       if (!this.g) {
         this.g = this.svg.append('g')
-          .attr('transform', `translate(0,${height - 17})`);
+          .attr('transform', `translate(0,${height - 15})`);
       }
 
       this.updateAxis();

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -86,7 +86,7 @@ export default {
       const height = this.$refs.workarea.clientHeight || 0;
       // clientWidth and clientHeight are properties used to resize child elements
       this.clientWidth = width;
-      // Timeline height needs to be offset so it doesn't overlap the frame number
+      // Timeline height needs to offset so it doesn't overlap the frame number
       this.clientHeight = height - 15;
       const scale = d3
         .scaleLinear()

--- a/client/src/components/layers/AnnotationLayer.vue
+++ b/client/src/components/layers/AnnotationLayer.vue
@@ -67,6 +67,11 @@ export default {
           this.$emit('annotation-right-click', e.data.record, e);
         }
       });
+    this.polygonFeature.geoOn(geo.event.mouseclick, (e) => {
+      if (this.polygonFeature.pointSearch(e.geo).found.length === 0) {
+        this.$emit('deselect-track');
+      }
+    });
     this.polygonFeature.geoOn(
       geo.event.feature.mouseclick_order,
       this.polygonFeature.mouseOverOrderClosestBorder,

--- a/client/src/components/layers/AnnotationLayer.vue
+++ b/client/src/components/layers/AnnotationLayer.vue
@@ -68,6 +68,7 @@ export default {
         }
       });
     this.polygonFeature.geoOn(geo.event.mouseclick, (e) => {
+      // If we aren't clicking on an annotation we can deselect the current track
       if (this.polygonFeature.pointSearch(e.geo).found.length === 0) {
         this.$emit('deselect-track');
       }

--- a/client/src/use/useAnnotationLayer.js
+++ b/client/src/use/useAnnotationLayer.js
@@ -15,11 +15,9 @@ export default function useAnnotationLayer({
     const _editingTrackId = editingTrackId.value;
     return {
       strokeColor: (a, b, data) => {
-        if (_editingTrackId !== null) {
-          if (_editingTrackId !== data.record.detection.track) {
-            if (stateStyling.disabled.color) {
-              return stateStyling.disabled.color;
-            }
+        if (_editingTrackId !== null && _editingTrackId !== data.record.detection.track) {
+          if (stateStyling.disabled.color) {
+            return stateStyling.disabled.color;
           }
         }
         if (data.record.detection.track === _selectedTrackId && stateStyling.selected.color) {
@@ -28,7 +26,7 @@ export default function useAnnotationLayer({
         if (data.record.detection.confidencePairs.length) {
           return typeColorMap(data.record.detection.confidencePairs[0][0]);
         }
-        return typeColorMap.range()[0];
+        return typeColorMap('');
       },
       strokeOpacity: (a, b, data) => {
         if (_editingTrackId !== null) {

--- a/client/src/use/useAnnotationLayer.js
+++ b/client/src/use/useAnnotationLayer.js
@@ -17,12 +17,12 @@ export default function useAnnotationLayer({
       strokeColor: (a, b, data) => {
         if (_editingTrackId !== null) {
           if (_editingTrackId !== data.record.detection.track) {
-            return stateStyling.disabled.color; // color for other objects when editing a detection
+            if (stateStyling.disabled.color) {
+              return stateStyling.disabled.color;
+            }
           }
-
-          return stateStyling.selected.color;
         }
-        if (data.record.detection.track === _selectedTrackId) {
+        if (data.record.detection.track === _selectedTrackId && stateStyling.selected.color) {
           return stateStyling.selected.color;
         }
         if (data.record.detection.confidencePairs.length) {
@@ -32,7 +32,7 @@ export default function useAnnotationLayer({
       },
       strokeOpacity: (a, b, data) => {
         if (_editingTrackId !== null) {
-          if (_editingTrackId !== data.record.detection.track) {
+          if (_editingTrackId !== data.record.detection.track && stateStyling.disabled.opacity) {
             return stateStyling.disabled.opacity;
           }
 
@@ -45,7 +45,14 @@ export default function useAnnotationLayer({
         return stateStyling.standard.opacity;
       },
       strokeWidth: (a, b, data) => {
-        if (data.record.detection.track === _selectedTrackId) {
+        if (_editingTrackId !== null) {
+          if (_editingTrackId !== data.record.detection.track
+            && stateStyling.disabled.strokeWidth) {
+            return stateStyling.disabled.strokeWidth;
+          }
+        }
+
+        if (data.record.detection.track === _selectedTrackId && stateStyling.selected.strokeWidth) {
           return stateStyling.selected.strokeWidth;
         }
         return stateStyling.standard.strokeWidth;

--- a/client/src/use/useStyling.js
+++ b/client/src/use/useStyling.js
@@ -8,7 +8,7 @@ export default function useStyling() {
   // Annotation State Colors
   const standard = {
     strokeWidth: 1,
-    opacity: 0.5,
+    opacity: 0.75,
   };
   const selected = {
     ...standard,
@@ -18,8 +18,8 @@ export default function useStyling() {
   };
   const disabled = {
     ...standard,
-    color: '#777777',
-    opacity: 0.7,
+    strokeWidth: 0.5,
+    opacity: 0.3,
   };
   // Colors provided for the different Types
   const stateStyling = { standard, selected, disabled };

--- a/client/src/use/useTextLayer.js
+++ b/client/src/use/useTextLayer.js
@@ -37,13 +37,13 @@ export default function useTextLayer({
     const _editingTrackId = editingTrackId.value;
     return {
       color: (data) => {
-        if (_editingTrackId !== null) {
+        if (_editingTrackId !== null && stateStyling.disabled.color) {
           if (_editingTrackId !== data.detection.track) {
             return stateStyling.disabled.color; // color for other detections when editing
           }
           return stateStyling.selected.color;
         }
-        if (data.detection.track === _selectedTrackId) {
+        if (data.detection.track === _selectedTrackId && stateStyling.selected.color) {
           return stateStyling.selected.color;
         }
         return typeColorMap(data.detection.confidencePairs[0][0]);

--- a/client/src/use/useTextLayer.js
+++ b/client/src/use/useTextLayer.js
@@ -37,11 +37,10 @@ export default function useTextLayer({
     const _editingTrackId = editingTrackId.value;
     return {
       color: (data) => {
-        if (_editingTrackId !== null && stateStyling.disabled.color) {
-          if (_editingTrackId !== data.detection.track) {
-            return stateStyling.disabled.color; // color for other detections when editing
+        if (_editingTrackId !== null && _editingTrackId !== data.detection.track) {
+          if (stateStyling.disabled.color) {
+            return stateStyling.disabled.color;
           }
-          return stateStyling.selected.color;
         }
         if (data.detection.track === _selectedTrackId && stateStyling.selected.color) {
           return stateStyling.selected.color;

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -168,7 +168,7 @@ export default {
     <NavigationBar />
     <v-container fill-height>
       <v-row
-        class="fill-height"
+        class="fill-height nowraptable"
         no-gutters
       >
         <v-col :cols="12">
@@ -249,3 +249,9 @@ export default {
     </v-container>
   </v-content>
 </template>
+
+<style lang='scss'>
+.nowraptable table thead tr th .row {
+  flex-wrap: nowrap;
+}
+</style>

--- a/client/src/views/Viewer/Viewer.vue
+++ b/client/src/views/Viewer/Viewer.vue
@@ -168,9 +168,25 @@ export default defineComponent({
         .range[0];
       seek(_frame);
     }
+    /**
+     * Iterates through frames using the keyboard and jumps to the first frame of the track.
+     * @param {('up' | 'down')} direction indicates if the previous or next track should be selected
+     */
+    function selectTrackFirstFrame(direction) {
+      if (direction === 'up') {
+        selectPreviousTrack();
+      } else if (direction === 'down') {
+        selectNextTrack();
+      }
+      gotoTrackFirstFrame(selectedTrack.value);
+    }
     function annotationClick(data) {
       if (!featurePointing.value) {
-        setTrackEditMode(data.detection.track, false);
+        if (data && data.detection && data.detection.track) {
+          setTrackEditMode(data.detection.track, false);
+        } else {
+          setTrackEditMode(null, false);
+        }
       }
     }
     function annotationRightClick(data) {
@@ -266,6 +282,7 @@ export default defineComponent({
       // Event Chart
       eventChartData,
       // local wrapper methods
+      selectTrackFirstFrame,
       gotoTrackFirstFrame,
       editTrack,
       seek,
@@ -368,8 +385,7 @@ export default defineComponent({
               @track-type-change="trackTypeChanged"
               @add-track="addTrack"
               @delete-track="deleteTrack"
-              @select-track-up="selectPreviousTrack"
-              @select-track-down="selectNextTrack"
+              @select-keyboard-track="selectTrackFirstFrame"
             />
           </div>
           <div
@@ -398,7 +414,7 @@ export default defineComponent({
             { bind: 'f', handler: () => nextFrame() },
             { bind: 'd', handler: () => prevFrame() },
             { bind: 'q', handler: deleteFeaturePoints },
-            { bind: 'esc', handler: () => setTrackEditMode(null, false)}
+            { bind: 'esc', handler: () => annotationClick(null)}
           ]"
           class="playback-component"
           :image-urls="imageUrls"
@@ -456,7 +472,7 @@ export default defineComponent({
             :annotation-style="annotationStyle"
             @annotation-click="annotationClick"
             @annotation-right-click="annotationRightClick"
-            @deselect-track="setTrackEditMode(null, false)"
+            @deselect-track="annotationClick(null)"
           />
           <edit-annotation-layer
             v-if="editingTrackId !== null && !playbackComponent.playing"

--- a/client/src/views/Viewer/Viewer.vue
+++ b/client/src/views/Viewer/Viewer.vue
@@ -169,7 +169,7 @@ export default defineComponent({
       seek(_frame);
     }
     /**
-     * Iterates through frames using the keyboard and jumps to the first frame of the track.
+     * Changes frames using the keyboard and jumps to the first frame of the track.
      * @param {('up' | 'down')} direction indicates if the previous or next track should be selected
      */
     function selectTrackFirstFrame(direction) {

--- a/client/src/views/Viewer/Viewer.vue
+++ b/client/src/views/Viewer/Viewer.vue
@@ -456,6 +456,7 @@ export default defineComponent({
             :annotation-style="annotationStyle"
             @annotation-click="annotationClick"
             @annotation-right-click="annotationRightClick"
+            @deselect-track="setTrackEditMode(null, false)"
           />
           <edit-annotation-layer
             v-if="editingTrackId !== null && !playbackComponent.playing"
@@ -464,7 +465,6 @@ export default defineComponent({
             :geojson="editingDetectionGeojson"
             :feature-style="editingBoxLayerStyle"
             @update:geojson="detectionChanged"
-            @update:editing="setTrackEditMode(selectedTrackId, $event)"
           />
           <edit-annotation-layer
             v-if="featurePointing"


### PR DESCRIPTION
Fixes #27 
Adds some simple CSS to force the Folder name to wrap instead of the buttons.
![image](https://user-images.githubusercontent.com/61746913/82595099-0b383a00-9b73-11ea-8ad5-c0c3f4cf1369.png)
I noticed that we do similar css updates to other parts of the GWC in the code so figured it wouldn't be a problem here.
![image](https://user-images.githubusercontent.com/61746913/82595171-26a34500-9b73-11ea-9496-ca31dd46084b.png)

Fixes #28 
This will deselect the current track if the user clicks on any area outside of any detection.
Added a new `geoOn.(geo.event.mouseclick, e)` event handler that will check all clicks and see if there is element under the mouse position.  GeoJS seems to have a built int feature for clicking on features but not for clicking off of one.  We could perhaps refactor this in the future to utilize one mouse event for all elements.  Part of this is also a change to utilizing `annotationClick` to make sure the user isn't editing a feature when they click.

Fixes #129 
I changed the keyboard function to include the `gotoTrackFirstFrame` ability as well.  This was a direct request.  I also saw an opportunity to clean up the emitted signals for changing the track.

Fixes #127
There was an issue in the previous version inside of `ImageAnnotator.vue` where when it detected that the next X frames to display a single second weren't loaded it would go back a frame and wait.  It before didn't emit that backward frame to the `AnnotationLayers` so they could draw the incorrect box.  Not helpful when dealing with single images.

Fixes #128 
The plot for the timeline had it's 0 for the y-axis below the frame numbers.  The plot would overlay the frame numbers at the bottom of the timeline.  I provided an offset, the same size as the numbers to make it look better.
Old Style:
![image](https://user-images.githubusercontent.com/61746913/82596020-9e25a400-9b74-11ea-93a9-983b858e1b00.png)
New Style:
![image](https://user-images.githubusercontent.com/61746913/82596039-a67ddf00-9b74-11ea-8d07-5dd8faa9f713.png)

Fixes #130 
The gray colors were a bit difficult to see so I removed the gray colors and changed the way the useStyles.js is utilized to allow to have some better fallbacks if the colors or opacity elements aren't there.
![image](https://user-images.githubusercontent.com/61746913/82596782-e98c8200-9b75-11ea-8936-1c98647f6a02.png)
Editing:
![image](https://user-images.githubusercontent.com/61746913/82596835-032dc980-9b76-11ea-95c2-03e024282b4a.png)


