### PR TITLE
Add dataclasses with general abstraction

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -25,6 +25,7 @@ setup(
     ],
     description="Server side functionality of VIAMEWeb",
     install_requires=requirements,
+    python_requires=">=3.7",
     license="Apache Software License 2.0",
     include_package_data=True,
     keywords="VIAME",

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -25,14 +25,14 @@ class Feature:
 class Track:
     begin: int
     end: int
-    key: int
+    trackId: str
     features: List[Feature] = field(default_factory=lambda: [])
     confidencePairs: Dict[str, float] = field(default_factory=lambda: {})
     attributes: Dict[str, Any] = field(default_factory=lambda: {})
 
 
 def row_info(row: List[str]) -> Tuple[int, int, List[float], float]:
-    trackid = int(row[0])
+    trackId = str(row[0])
     frame = int(row[2])
     bounds = [
         float(row[3]),
@@ -42,7 +42,7 @@ def row_info(row: List[str]) -> Tuple[int, int, List[float], float]:
     ]
     fish_length = float(row[8])
 
-    return trackid, frame, bounds, fish_length
+    return trackId, frame, bounds, fish_length
 
 
 def _deduceType(value: str) -> Union[bool, float, str]:
@@ -93,7 +93,7 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List]:
 
 def _parse_row_for_tracks(row: List[str]) -> Tuple[Feature, Dict, Dict, List]:
     head_tail_feature, attributes, track_attributes, confidence_pairs = _parse_row(row)
-    trackid, frame, bounds, fishLength = row_info(row)
+    trackId, frame, bounds, fishLength = row_info(row)
 
     feature = Feature(
         frame,
@@ -153,12 +153,12 @@ def load_csv_as_tracks(file):
             track_attributes,
             confidence_pairs,
         ) = _parse_row_for_tracks(row)
-        trackid, frame, _, _ = row_info(row)
+        trackId, frame, _, _ = row_info(row)
 
-        if trackid not in tracks:
-            tracks[trackid] = Track(frame, frame, trackid)
+        if trackId not in tracks:
+            tracks[trackId] = Track(frame, frame, trackId)
 
-        track = tracks[trackid]
+        track = tracks[trackId]
         track.begin = min(frame, track.begin)
         track.features.append(feature)
 
@@ -173,4 +173,4 @@ def load_csv_as_tracks(file):
             for (key, val) in confidence_pairs:
                 track.confidencePairs[key] = val
 
-    return {trackid: asdict(track) for trackid, track in tracks.items()}
+    return {trackId: asdict(track) for trackId, track in tracks.items()}

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -15,8 +15,8 @@ class Feature:
 
     frame: int = None
     bounds: List[float] = None
-    head: Optional[Tuple[str, str]] = None
-    tail: Optional[Tuple[str, str]] = None
+    head: Optional[Tuple[int, int]] = None
+    tail: Optional[Tuple[int, int]] = None
     fishLength: Optional[float] = None
     attributes: Optional[Dict[str, Union[bool, float, str]]] = None
 

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -25,7 +25,7 @@ class Feature:
 class Track:
     begin: int
     end: int
-    trackId: str
+    trackId: int
     features: List[Feature] = field(default_factory=lambda: [])
     confidencePairs: List[Tuple[str, float]] = field(default_factory=lambda: [])
     attributes: Dict[str, Any] = field(default_factory=lambda: {})
@@ -44,8 +44,8 @@ def track_to_dict(track: Track):
     return track_dict
 
 
-def row_info(row: List[str]) -> Tuple[str, int, List[float], float]:
-    trackId = str(row[0])
+def row_info(row: List[str]) -> Tuple[int, int, List[float], float]:
+    trackId = int(row[0])
     frame = int(row[2])
     bounds = [
         float(row[3]),

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -160,17 +160,11 @@ def load_csv_as_tracks(file):
 
         track = tracks[trackId]
         track.begin = min(frame, track.begin)
+        track.end = max(track.end, frame)
         track.features.append(feature)
+        track.confidencePairs = confidence_pairs
 
         for (key, val) in track_attributes:
             track.attributes[key] = val
-
-        if frame > track.end:
-            track.end = frame
-
-            # final confidence pair should be taken as the
-            # pair that applied to the whole track
-            for (key, val) in confidence_pairs:
-                track.confidencePairs[key] = val
 
     return {trackId: asdict(track) for trackId, track in tracks.items()}

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -91,7 +91,7 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List]:
     return features, attributes, track_attributes, confidence_pairs
 
 
-def _parse_row_for_tracks(row: List[str]) -> Tuple[Feature, Any, Any, Any]:
+def _parse_row_for_tracks(row: List[str]) -> Tuple[Feature, Dict, Dict, List]:
     head_tail_feature, attributes, track_attributes, confidence_pairs = _parse_row(row)
     trackid, frame, bounds, fishLength = row_info(row)
 


### PR DESCRIPTION
Fixes #131 

This is a first pass at adding dataclasses, and also adds a bit of abstraction to the operations we're doing. I think this makes it easier to read.

This also adds a good bit of typing information, which I think adds clarity. The main drive for me adding type annotations during this PR was mainly any code that I touched, however I could add more if it's desired. Also, if we generally like this, it might be worth it to add `mypy` or something similar, so we can do static type checking and take full advantage of type hints.