### PR TITLE
Add Continuous Deployment

### DIFF
--- a/docker/ansible/README.md
+++ b/docker/ansible/README.md
@@ -1,5 +1,8 @@
 This folder contains the deployment configuration for Viame-Web
 
+
+Typically ansible is run using `ansible-playbook` over `ssh`, however since the server this is deployed on isn't accessable via `ssh`, we can't use normal CI/Deployment methods. Instead, ansible needs to be run with a `systemd` timer, and this `systemd` timer needs to be setup locally. Due to the uptime requirements, this deployment is run on a schedule, instead of directly after changes to the `master` branch.
+
 # Requirements
 The server must have the following things:
 - The repository cloned to `/home/viame`
@@ -8,7 +11,7 @@ The server must have the following things:
 
 
 # systemd service
-To initiate the systemd timer, run the following command:
+To initiate the `systemd` timer, run the following command:
 
 ```
 ansible-playbook docker/ansible/systemd.yml

--- a/docker/ansible/README.md
+++ b/docker/ansible/README.md
@@ -1,0 +1,24 @@
+This folder contains the deployment configuration for Viame-Web
+
+# Requirements
+The server must have the following things:
+- The repository cloned to `/home/viame`
+- Ansible
+- The Ansible [Docker Compose](https://docs.ansible.com/ansible/latest/modules/docker_compose_module.html) module
+
+
+# systemd service
+To initiate the systemd timer, run the following command:
+
+```
+ansible-playbook docker/ansible/systemd.yml
+```
+
+If you need to remove this timer and service, run the following command:
+
+```
+ansible-playbook docker/ansible/clean.systemd.yml
+```
+
+# Operation
+Once the service is initiated, it will run the `deploy.yml` playbook at the interval specified in `viame-deploy.timer`. This will update the server with any changes.

--- a/docker/ansible/clean.systemd.yml
+++ b/docker/ansible/clean.systemd.yml
@@ -1,0 +1,25 @@
+# Playbook to install the systemd service and timers files
+
+- hosts: localhost
+  become: yes
+  vars:
+    # Required to use docker_compose properly
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Disable timer
+      systemd:
+          name: viame-deploy.timer
+          state: stopped
+          enabled: no
+          daemon_reload: yes
+
+    - name: Remove systemd service
+      file:
+        path: /etc/systemd/system/viame-deploy.service
+        state: absent
+
+    - name: Remove systemd timer
+      file:
+        path: /etc/systemd/system/viame-deploy.timer
+        state: absent
+

--- a/docker/ansible/clean.systemd.yml
+++ b/docker/ansible/clean.systemd.yml
@@ -1,4 +1,4 @@
-# Playbook to install the systemd service and timers files
+# Playbook to remove the systemd service and timers files
 
 - hosts: localhost
   become: yes
@@ -22,4 +22,3 @@
       file:
         path: /etc/systemd/system/viame-deploy.timer
         state: absent
-

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -1,0 +1,21 @@
+# Playbook that updates the current instance
+
+- hosts: localhost
+  vars:
+    # Required to use docker_compose properly
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Stop Currently Running Service
+      docker_compose:
+        project_src: /home/viame/docker
+        state: absent
+
+    - name: Pull Repository Changes
+      shell: git pull
+      args:
+        chdir: /home/viame
+
+    - name: Restart and Build Service
+      docker_compose:
+        project_src: /home/viame/docker
+        build: yes

--- a/docker/ansible/main.yml
+++ b/docker/ansible/main.yml
@@ -1,0 +1,18 @@
+# Playbook that runs all included playbooks
+
+- hosts: localhost
+  vars:
+    # Required to use docker_compose properly
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Pull Repository Changes
+      shell: git pull
+      args:
+        chdir: /home/viame
+
+
+- name: Include systemd playbook
+  include: systemd.yml
+
+- name: Include deploy playbook
+  include: deploy.yml

--- a/docker/ansible/systemd.yml
+++ b/docker/ansible/systemd.yml
@@ -19,6 +19,6 @@
     - name: Enable timer
       systemd:
           name: viame-deploy.timer
-          state: started
+          state: restarted
           enabled: yes
           daemon_reload: yes

--- a/docker/ansible/systemd.yml
+++ b/docker/ansible/systemd.yml
@@ -9,7 +9,7 @@
   tasks:
     - name: Copy systemd service
       copy:
-        src: "{{ viame_install_location  }}/docker/ansible/viame-deploy.service"
+        src: "{{ viame_install_location }}/docker/ansible/viame-deploy.service"
         dest: /etc/systemd/system/viame-deploy.service
 
     - name: Copy systemd timer

--- a/docker/ansible/systemd.yml
+++ b/docker/ansible/systemd.yml
@@ -5,16 +5,15 @@
   vars:
     # Required to use docker_compose properly
     ansible_python_interpreter: /usr/bin/python3
-    viame_install_location: /home/viame
   tasks:
     - name: Copy systemd service
       copy:
-        src: "{{ viame_install_location }}/docker/ansible/viame-deploy.service"
+        src: /home/viame/docker/ansible/viame-deploy.service
         dest: /etc/systemd/system/viame-deploy.service
 
     - name: Copy systemd timer
       copy:
-        src: "{{ viame_install_location }}/docker/ansible/viame-deploy.timer"
+        src: /home/viame/docker/ansible/viame-deploy.timer
         dest: /etc/systemd/system/viame-deploy.timer
 
     - name: Enable timer

--- a/docker/ansible/systemd.yml
+++ b/docker/ansible/systemd.yml
@@ -16,8 +16,9 @@
         src: /home/viame/docker/ansible/viame-deploy.timer
         dest: /etc/systemd/system/viame-deploy.timer
 
-    - name: Reload systemd daemon
+    - name: Enable timer
       systemd:
-          name: viame-deploy
+          name: viame-deploy.timer
+          state: started
           enabled: yes
           daemon_reload: yes

--- a/docker/ansible/systemd.yml
+++ b/docker/ansible/systemd.yml
@@ -1,0 +1,23 @@
+# Playbook to install the systemd service and timers files
+
+- hosts: localhost
+  become: yes
+  vars:
+    # Required to use docker_compose properly
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Copy systemd service
+      copy:
+        src: /home/viame/docker/ansible/viame-deploy.service
+        dest: /etc/systemd/system/viame-deploy.service
+
+    - name: Copy systemd timer
+      copy:
+        src: /home/viame/docker/ansible/viame-deploy.timer
+        dest: /etc/systemd/system/viame-deploy.timer
+
+    - name: Reload systemd daemon
+      systemd:
+          name: viame-deploy
+          enabled: yes
+          daemon_reload: yes

--- a/docker/ansible/systemd.yml
+++ b/docker/ansible/systemd.yml
@@ -5,15 +5,16 @@
   vars:
     # Required to use docker_compose properly
     ansible_python_interpreter: /usr/bin/python3
+    viame_install_location: /home/viame
   tasks:
     - name: Copy systemd service
       copy:
-        src: /home/viame/docker/ansible/viame-deploy.service
+        src: "{{ viame_install_location  }}/docker/ansible/viame-deploy.service"
         dest: /etc/systemd/system/viame-deploy.service
 
     - name: Copy systemd timer
       copy:
-        src: /home/viame/docker/ansible/viame-deploy.timer
+        src: "{{ viame_install_location }}/docker/ansible/viame-deploy.timer"
         dest: /etc/systemd/system/viame-deploy.timer
 
     - name: Enable timer

--- a/docker/ansible/viame-deploy.service
+++ b/docker/ansible/viame-deploy.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Update the Viame Instance
+
+[Service]
+ExecStart=/usr/local/bin/ansible-playbook /home/viame/docker/ansible/deploy.yml
+Type=oneshot

--- a/docker/ansible/viame-deploy.timer
+++ b/docker/ansible/viame-deploy.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run the Viame deploy every Sunday at midnight
+Description=Run the Viame deploy every Sunday at 2 AM
 
 [Timer]
 OnCalendar=Sun 02:00

--- a/docker/ansible/viame-deploy.timer
+++ b/docker/ansible/viame-deploy.timer
@@ -2,8 +2,8 @@
 Description=Run the Viame deploy every Sunday and Thursday at 2 AM
 
 [Timer]
-OnCalendar=Sun 02:00
-OnCalendar=Thu 02:00
+OnCalendar=Sun 02:00 America/New_York
+OnCalendar=Thu 02:00 America/New_York
 Persistent=true
 
 [Install]

--- a/docker/ansible/viame-deploy.timer
+++ b/docker/ansible/viame-deploy.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run the Viame deploy every Sunday at 2 AM
+Description=Run the Viame deploy every Sunday and Thursday at 2 AM
 
 [Timer]
 OnCalendar=Sun 02:00

--- a/docker/ansible/viame-deploy.timer
+++ b/docker/ansible/viame-deploy.timer
@@ -3,6 +3,7 @@ Description=Run the Viame deploy every Sunday at 2 AM
 
 [Timer]
 OnCalendar=Sun 02:00
+OnCalendar=Thu 02:00
 Persistent=true
 
 [Install]

--- a/docker/ansible/viame-deploy.timer
+++ b/docker/ansible/viame-deploy.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run the Viame deploy every Sunday at midnight
+
+[Timer]
+OnCalendar=Sun 02:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Fixes #36 

Currently, this PR only updates code, and updating `deploy.yml` will have no effect, until updated manually on the server. If this is desired, the `main.yml` playbook would allow for this, as this runs both the systemd playbook, and the deploy playbook. However, the reason I haven't included it here is that I'm not sure if we even need to worry about the `systemd` files changing, and including that would mean that we need to do more work around storing a user's `sudo` password.