### PR TITLE
Save Track JSON

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -9,6 +9,7 @@ requirements = [
     "girder_worker==0.6.0",
     "girder_worker_utils==0.8.5",
     "pysnooper",
+    "dacite",
 ]
 
 setup(

--- a/server/viame_server/event.py
+++ b/server/viame_server/event.py
@@ -2,10 +2,8 @@ from girder.models.folder import Folder
 from girder.models.item import Item
 
 from viame_server.utils import (
-    itemIsWebsafeVideo,
     validImageFormats,
     ImageSequenceType,
-    VideoType,
 )
 
 
@@ -39,7 +37,7 @@ def maybe_mark_folder_for_annotation(event):
     """
     info = event.info
 
-    if info["parentType"] != "folder":
+    if "parentType" not in info or info["parentType"] != "folder":
         return
 
     parent = Folder().findOne({"_id": info["parentId"]})

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -50,12 +50,8 @@ class Track:
 def row_info(row: List[str]) -> Tuple[int, int, List[float], float]:
     trackId = int(row[0])
     frame = int(row[2])
-    bounds = [
-        float(row[3]),
-        float(row[5]),
-        float(row[4]),
-        float(row[6]),
-    ]
+
+    bounds = [float(x) for x in row[3:7]]
     fish_length = float(row[8])
 
     return trackId, frame, bounds, fish_length

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -178,7 +178,7 @@ def write_track_to_csv(track: Track, csv_writer):
             feature.frame,
             *feature.bounds,
             track.confidencePairs[-1][1],
-            feature.fishLength,
+            feature.fishLength or -1,
         ]
 
         for pair in track.confidencePairs:

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -23,6 +23,10 @@ class Feature:
     fishLength: Optional[float] = None
     attributes: Optional[Dict[str, Union[bool, float, str]]] = None
 
+    def asdict(self):
+        """Removes entries with values of `None`."""
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
 
 @dataclass
 class Track:
@@ -33,18 +37,14 @@ class Track:
     confidencePairs: List[Tuple[str, float]] = field(default_factory=lambda: [])
     attributes: Dict[str, Any] = field(default_factory=lambda: {})
 
+    def asdict(self):
+        """Used instead of `dataclasses.asdict` for better performance."""
 
-def track_to_dict(track: Track):
-    """Used instead of `asdict` for better performance."""
-
-    def omit_empty(d):
-        return {k: v for k, v in d.items() if v is not None}
-
-    track_dict = dict(track.__dict__)
-    track_dict["features"] = [
-        omit_empty(feature.__dict__) for feature in track_dict["features"]
-    ]
-    return track_dict
+        track_dict = dict(self.__dict__)
+        track_dict["features"] = [
+            feature.asdict() for feature in track_dict["features"]
+        ]
+        return track_dict
 
 
 def row_info(row: List[str]) -> Tuple[int, int, List[float], float]:
@@ -159,7 +159,7 @@ def load_csv_as_tracks(file):
         for (key, val) in track_attributes:
             track.attributes[key] = val
 
-    return {trackId: track_to_dict(track) for trackId, track in tracks.items()}
+    return {trackId: track.asdict() for trackId, track in tracks.items()}
 
 
 def write_track_to_csv(track: Track, csv_writer):

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -124,9 +124,13 @@ class ViameDetection(Resource):
         detectionItems.sort(key=lambda d: d["created"], reverse=True)
         item = detectionItems[0]
         file = Item().childFiles(item)[0]
+
+        if "csv" in file["exts"]:
+            return File().download(file)
+
         filename = ".".join([file["name"].split(".")[:-1][0], "csv"])
 
-        csv_string = viame.export_json_as_csv(file)
+        csv_string = viame.export_tracks_as_csv(file)
         csv_bytes = csv_string.encode()
 
         assetstore = Assetstore().findOne({"_id": file["assetstoreId"]})

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -1,7 +1,5 @@
-import csv
 import io
 import json
-import re
 import urllib
 from datetime import datetime
 
@@ -14,7 +12,7 @@ from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.upload import Upload
-from girder.utility import ziputil
+from girder.models.assetstore import Assetstore
 
 from viame_server.serializers import viame
 from viame_server.utils import (
@@ -34,6 +32,7 @@ class ViameDetection(Resource):
         self.route("PUT", (), self.save_detection)
         self.route("GET", ("clip_meta",), self.get_clip_meta)
         self.route("GET", (":id", "export",), self.export_data)
+        self.route("GET", (":id", "export_detections",), self.export_detections)
 
     def _get_clip_meta(self, folder):
         detections = list(
@@ -105,6 +104,43 @@ class ViameDetection(Resource):
 
     @access.user
     @autoDescribeRoute(
+        Description("Export detections of a clip into CSV format.")
+        .modelParam(
+            "id",
+            description="folder id of a clip",
+            model=Folder,
+            required=True,
+            level=AccessType.READ,
+        )
+    )
+    def export_detections(self, folder):
+        user = self.getCurrentUser()
+
+        detectionItems = list(
+            Item().findWithPermissions(
+                {"meta.detection": str(folder["_id"])}, user=self.getCurrentUser(),
+            )
+        )
+        detectionItems.sort(key=lambda d: d["created"], reverse=True)
+        item = detectionItems[0]
+        file = Item().childFiles(item)[0]
+        filename = ".".join([file["name"].split(".")[:-1][0], "csv"])
+
+        csv_string = viame.export_json_as_csv(file)
+        csv_bytes = csv_string.encode()
+
+        assetstore = Assetstore().findOne({"_id": file["assetstoreId"]})
+        new_file = File().findOne({"name": filename}) or File().createFile(
+            user, item, filename, len(csv_bytes), assetstore
+        )
+
+        upload = Upload().createUploadToFile(new_file, user, len(csv_bytes))
+        new_file = Upload().handleChunk(upload, csv_bytes)
+
+        return File().download(new_file)
+
+    @access.user
+    @autoDescribeRoute(
         Description("Get detections of a clip")
         .modelParam(
             "folderId",
@@ -114,23 +150,22 @@ class ViameDetection(Resource):
             required=True,
             level=AccessType.READ,
         )
-        .param("formatting", "Format to fetch", default="track_json",)
     )
-    def get_detection(self, folder, formatting):
+    def get_detection(self, folder):
         detectionItems = list(
             Item().findWithPermissions(
                 {"meta.detection": str(folder["_id"])}, user=self.getCurrentUser(),
             )
         )
         detectionItems.sort(key=lambda d: d["created"], reverse=True)
+
         if not len(detectionItems):
             return None
+
         file = Item().childFiles(detectionItems[0])[0]
-        if formatting == "track_json":
+        if "csv" in file["exts"]:
             return viame.load_csv_as_tracks(file)
-        elif formatting == "detection_json":
-            return viame.load_csv_as_detections(file)
-        raise RestException(f"formatting {formatting} is not recognized")
+        return File().download(file, contentDisposition="inline")
 
     @access.user
     @autoDescribeRoute(
@@ -157,76 +192,30 @@ class ViameDetection(Resource):
             required=True,
             level=AccessType.READ,
         )
-        .jsonParam("detections", "", requireArray=True, paramType="body")
+        .jsonParam("tracks", "", requireArray=True, paramType="body")
     )
-    def save_detection(self, folder, detections):
+    def save_detection(self, folder, tracks):
         user = self.getCurrentUser()
 
-        def valueToString(value):
-            if value is True:
-                return "true"
-            elif value is False:
-                return "false"
-            return str(value)
-
-        def getRow(d, trackAttributes=None):
-            columns = [
-                d["track"],
-                "",
-                d["frame"],
-                d["bounds"][0],
-                d["bounds"][2],
-                d["bounds"][1],
-                d["bounds"][3],
-                d["confidence"],
-                d["fishLength"],
-            ]
-            for [key, confidence] in d["confidencePairs"]:
-                columns += [key, confidence]
-            if d["features"]:
-                for [key, values] in d["features"].items():
-                    columns.append("(kp) {} {} {}".format(key, values[0], values[1]))
-            if d["attributes"]:
-                for [key, value] in d["attributes"].items():
-                    columns.append("(atr) {} {}".format(key, valueToString(value)))
-            if trackAttributes:
-                for [key, value] in trackAttributes.items():
-                    columns.append("(trk-atr) {} {}".format(key, valueToString(value)))
-            return columns
-
-        detections.sort(key=lambda d: d["track"])
-
-        csvFile = io.StringIO()
-        writer = csv.writer(csvFile)
-        trackAttributes = None
-        length = len(detections)
-        track = detections[0]["track"]
-        for i in range(0, len(detections)):
-            trackAttributes = (
-                detections[i]["trackAttributes"]
-                if detections[i]["trackAttributes"]
-                else None
-            )
-            if i == length - 1 or detections[i + 1]["track"] != track:
-                writer.writerow(getRow(detections[i], trackAttributes))
-            else:
-                writer.writerow(getRow(detections[i]))
+        timestamp = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
+        item_name = f"result_{timestamp}.json"
 
         move_existing_result_to_auxiliary_folder(folder, user)
-
-        timestamp = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
-        newResultItem = Item().createItem("result_" + timestamp + ".csv", user, folder)
+        newResultItem = Item().createItem(item_name, user, folder)
         Item().setMetadata(
             newResultItem, {"detection": str(folder["_id"])}, allowNull=True,
         )
-        theBytes = csvFile.getvalue().encode()
-        byteIO = io.BytesIO(theBytes)
+
+        json_bytes = json.dumps(tracks).encode()
+        byteIO = io.BytesIO(json_bytes)
         Upload().uploadFromFile(
             byteIO,
-            len(theBytes),
-            "result.csv",
+            len(json_bytes),
+            item_name,
             parentType="item",
             parent=newResultItem,
             user=user,
+            mimeType="application/json",
         )
+
         return True

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -196,7 +196,7 @@ class ViameDetection(Resource):
             required=True,
             level=AccessType.READ,
         )
-        .jsonParam("tracks", "", requireArray=True, paramType="body")
+        .jsonParam("tracks", "", paramType="body")
     )
     def save_detection(self, folder, tracks):
         user = self.getCurrentUser()


### PR DESCRIPTION
Depends on #136.

This PR changes the saving of detection into girder by always saving as Track JSON. This also maintains backwards compatibility. This is because if the latest detection file in girder is a CSV, it will call the functions that were already in place, but if not, it will either simply return the contents of the file, or convert it to `track_json` first, and then return it.

To maintain the CSV format in some way, I've added an `export_detections` endpoint, which serializes the JSON format back into the CSV format we've been using. This was mainly done by moving code from the `save_detection` endpoint (which used to do exactly this) into this endpoint.

Now, there are two cases for retrieving detections:
* Track JSON, from a CSV file
* Track JSON, from a JSON file

To my knowledge, I've made the response consistent between CSV/JSON backend storage, but if you find something I've missed, please lmk.