### PR TITLE
Use python3.7 instead of python

### DIFF
--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
   apt-get update && apt-get install -qy \
     build-essential \
     wget \
-    python3 \
+    python3.7 \
     r-base \
     libffi-dev \
     libssl-dev \
@@ -19,10 +19,10 @@ RUN apt-get update && \
     zlib1g-dev \
     r-base \
     ffmpeg \
-    libpython3-dev && \
+    libpython3.7-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3.7 get-pip.py
 # END port of worker installation
 
 # install tini init system
@@ -43,5 +43,5 @@ RUN useradd -D --shell=/bin/bash && useradd -m worker
 RUN chown -R worker:worker /usr/local/lib/python*
 USER worker
 
-ENTRYPOINT ["/tini", "--", "python3", "-m", "girder_worker" ]
+ENTRYPOINT ["/tini", "--", "python3.7", "-m", "girder_worker" ]
 CMD [ "-l", "info" ]

--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -30,6 +30,8 @@ ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
+RUN pip install future
+
 # Pip install dependencies
 COPY server/setup.py /home/viame_girder/
 RUN pip install --no-cache-dir .


### PR DESCRIPTION
This was never bumped in #136, so before this change it failed to build. We might want to consider adding CI that runs the build to ensure it succeeds.