### PR TITLE
Updates to fix several issues

### DIFF
--- a/client/src/@types/vue-utilities.d.ts
+++ b/client/src/@types/vue-utilities.d.ts
@@ -1,9 +1,16 @@
 import Vue from 'vue';
 
+interface PromptParams {
+  title: string;
+      text: string;
+      positiveButton?: string;
+       negativeButton?: string;
+       confirm?: boolean;
+}
 declare module 'vue/types/vue' {
   interface Vue {
     $promptAttach(): Vue;
-    $prompt(): Promise<unknown>;
+    $prompt(arg: PromptParams): Promise<unknown>;
     $snackbarAttach(): Vue;
     $snackbar(): Promise<unknown>;
   }

--- a/client/src/@types/vue-utilities.d.ts
+++ b/client/src/@types/vue-utilities.d.ts
@@ -4,8 +4,8 @@ interface PromptParams {
   title: string;
       text: string;
       positiveButton?: string;
-       negativeButton?: string;
-       confirm?: boolean;
+      negativeButton?: string;
+      confirm?: boolean;
 }
 declare module 'vue/types/vue' {
   interface Vue {

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -159,10 +159,14 @@ export default Vue.extend({
     <v-virtual-scroll
       ref="virtualList"
       v-mousetrap="[
-        { bind: 'up', handler: (el, event) => scrollPreventDefault(el, event, 'up') },
-        { bind: 'down', handler: (el, event) => scrollPreventDefault(el, event, 'down') },
-        { bind: 'enter', handler: () => $emit('track-click', selectedTrackId.value)},
-        { bind: 'del', handler: () => $emit('track-remove', selectedTrackId.value)},
+        { bind: 'up', handler: (el, event) => scrollPreventDefault(el, event, 'up'),
+          disabled: $prompt.visible() },
+        { bind: 'down', handler: (el, event) => scrollPreventDefault(el, event, 'down'),
+          disabled: $prompt.visible() },
+        { bind: 'enter', handler: () => $emit('track-click', selectedTrackId.value),
+          disabled: $prompt.visible()},
+        { bind: 'del', handler: () => $emit('track-remove', selectedTrackId.value),
+          disabled: $prompt.visible()},
       ]"
       :items="virtualListItems"
       :item-height="itemHeight"

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -165,7 +165,8 @@ export default Vue.extend({
           disabled: $prompt.visible() },
         { bind: 'enter', handler: () => $emit('track-click', selectedTrackId.value),
           disabled: $prompt.visible()},
-        { bind: 'del', handler: () => $emit('track-remove', selectedTrackId.value),
+        { bind: 'del', handler: () =>
+            selectedTrackId.value !== null && $emit('track-remove', selectedTrackId.value),
           disabled: $prompt.visible()},
       ]"
       :items="virtualListItems"

--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -50,11 +50,11 @@ export default {
 <template>
   <div
     v-mousetrap="[
-      { bind: 'left', handler: previousFrame },
-      { bind: 'right', handler: nextFrame },
-      { bind: 'space', handler: togglePlay },
-      { bind: 'f', handler: nextFrame },
-      { bind: 'd', handler: previousFrame },
+      { bind: 'left', handler: previousFrame, disabled: $prompt.visible() },
+      { bind: 'right', handler: nextFrame, disabled: $prompt.visible()},
+      { bind: 'space', handler: togglePlay, disabled: $prompt.visible() },
+      { bind: 'f', handler: nextFrame, disabled: $prompt.visible() },
+      { bind: 'd', handler: previousFrame, disabled: $prompt.visible() },
     ]"
   >
     <v-toolbar

--- a/client/src/components/layers/EditAnnotationLayer.ts
+++ b/client/src/components/layers/EditAnnotationLayer.ts
@@ -127,7 +127,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
         this.applyStylesToAnnotations();
         // State doesn't change at the end of editing so this will
         // swap into edit mode once geoJS is done
-        setTimeout(() => this.$emit('update:geojson', this.formattedData[0], true), 0);
+        setTimeout(() => this.$emit('update:geojson', this.formattedData[0]), 0);
       }
     }
   }

--- a/client/src/lib/vue-utilities/prompt-service/Prompt.vue
+++ b/client/src/lib/vue-utilities/prompt-service/Prompt.vue
@@ -9,6 +9,7 @@ export default {
     text: '',
     positiveButton: 'Confirm',
     negativeButton: 'Cancel',
+    selected: 'positive',
     confirm: false,
     resolve: null,
   }),
@@ -16,6 +17,9 @@ export default {
     show(value) {
       if (!value) {
         this.resolve(false);
+      } else {
+        // Needs to mount and then dialog transition, single tick doesn't work
+        this.$nextTick(() => this.$nextTick(() => this.$refs.positive.$el.focus()));
       }
     },
   },
@@ -27,6 +31,19 @@ export default {
     positive() {
       this.show = false;
       this.resolve(true);
+    },
+    focus(direction) {
+      if (this.$refs[direction]) {
+        this.$refs[direction].$el.focus();
+        this.selected = direction;
+      }
+    },
+    select() {
+      if (this.selected === 'positive') {
+        this.positive();
+      } else {
+        this.negative();
+      }
     },
   },
 };
@@ -40,6 +57,11 @@ export default {
     <v-card>
       <v-card-title
         v-if="title"
+        v-mousetrap="[
+          { bind: 'left', handler: () => focus('negative') },
+          { bind: 'right', handler: () => focus('positive') },
+          { bind: 'enter', handler: () => select() },
+        ]"
         class="title"
       >
         {{ title }}
@@ -51,12 +73,14 @@ export default {
         <v-spacer />
         <v-btn
           v-if="confirm"
+          ref="negative"
           text
           @click="negative"
         >
           {{ negativeButton }}
         </v-btn>
         <v-btn
+          ref="positive"
           color="primary"
           text
           @click="positive"

--- a/client/src/lib/vue-utilities/prompt-service/index.js
+++ b/client/src/lib/vue-utilities/prompt-service/index.js
@@ -44,6 +44,7 @@ export default function (vuetify) {
       }
       return p;
     };
+    Vue.prototype.$prompt.visible = () => component.$data.show;
     Vue.prototype.$prompt.hide = () => {
       component.$data.show = false;
     };

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -58,9 +58,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
       intervalTree.remove(oldInterval, track.trackId);
       intervalTree.insert([track.begin, track.end], track.trackId);
     }
-    if (event !== 'feature') {
-      canary.value += 1;
-    }
+    canary.value += 1;
     markChangesPending();
   }
 

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -137,9 +137,6 @@ export default defineComponent({
     const location = computed(() => store.state.location);
 
     async function removeTrack(trackId: TrackId) {
-      if (selectedTrackId === null) {
-        return;
-      }
       const result = await prompt({
         title: 'Confirm',
         text: 'Do you want to delete selected items?',

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -59,7 +59,12 @@ export default defineComponent({
     },
   },
 
-  setup(props) {
+  setup(props, ctx) {
+    // TODO: eventually we will have to migrate away from this style
+    // and use the new plugin pattern:
+    // https://vue-composition-api-rfc.netlify.com/#plugin-development
+    const prompt = ctx.root.$prompt;
+
     const { datasetId } = props;
     const playbackComponent = ref({} as Seeker);
     const frame = ref(0); // the currently displayed frame number
@@ -131,7 +136,18 @@ export default defineComponent({
 
     const location = computed(() => store.state.location);
 
-    function removeTrack(trackId: TrackId) {
+    async function removeTrack(trackId: TrackId) {
+      if (selectedTrackId === null) {
+        return;
+      }
+      const result = await prompt({
+        title: 'Confirm',
+        text: 'Do you want to delete selected items?',
+        confirm: true,
+      });
+      if (!result) {
+        return;
+      }
       // if removed track was selected, unselect before remove
       if (selectedTrackId.value === trackId) {
         selectNextTrack(1);


### PR DESCRIPTION
Some additional changes and fixes to the track-centric stuff

- Added in the Prompt - I decided to use the existing style because of the usage in the Home.vue for file deletion.  We can in the future decide to switch this over to a composition function I think fairly easily and then just have it is used by the other items.
- Within Prompt I added Keyboard functions for the focusing of elements.  the `NextTick( () => NextTick())` is done because the element is mounted initially.  It changes visibility on `show` so we need it to mount, then there is a delay then we can focus on the confirm
- Prompt now has a visible() function call to see if the prompt is visible on the screen it is used in v-mousetrap
- mousetrap changes to disable certain keyboard functions if the prompt is visible
- Removed all references to the `annotationChanged` function which was unneeded 
- Bug in interval search tree would return array tuples if the value was falsey so we can implement our own function in there instead of utilizing the default.