### PR TITLE
Update to prevent dual draw calls when editing tracks

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -49,9 +49,12 @@ function getResponseError(error: AxiosError): string | AxiosError {
  * removes and adds changed values.  If a value is in both old and new superset
  * and omitted from subset, it will remain omitted
  */
-function updateSubset<T>(oldarr: Readonly<Array<T>>, newarr: Readonly<Array<T>>) {
+function updateSubset<T>(oldarr: Array<T>, newarr: Readonly<Array<T>>) {
   const addedValues = difference(newarr, oldarr);
   const removedValues = difference(oldarr, newarr);
+  if (!addedValues.length && !removedValues.length) {
+    return oldarr;
+  }
   const oldset = new Set(oldarr);
   addedValues.forEach((v) => oldset.add(v));
   removedValues.forEach((v) => oldset.delete(v));


### PR DESCRIPTION
The editing track can't reinitialize immediately after finishing the edit.  If it does it needs the cursor to move off and on a handle to be able to grab it.  I understand that geoJS probably relies on mouseover to trigger ability to select an edit handle.  I've updated the internal data of `editAnnotationLayer` to utilize the `this.changed` function which was the original solution to this problem.  This will allow an object to be edited and then prevent re initialization on the next draw call.

If you look at how `useTrackFilters` functions there are some cascading computed properties as well as watchers that cause side effects to data values then used in the computed properties.

The best way to view it is working backwards from the end product back to the changed item when an edit occurs.
`enabledTrackIds` depends on `checkedTrackIds` and `filteredTrackIds`
`checkedTrackIds` depends on `sortedTrackIds` and has a watcher on `sortedTrackIds` which will update it
`filteredTrackIds` depends on `checkedTypes`, `sortedTrackIds` and `confidenceThreshold` (don't worry about confidenceThreashold)
`checkedTypes` depends on `allTypes` and has a watcher on `allTypes` which will update it.
`allTypes` is computed from `sortedTrackIds`

When `sortedTrackId` changes it has a cascading effect across all of these properties.  The order in which they are updated causes some issues, where it looks like the watchers on the `sortedTrackIds` and `allTypes` are fired near the end, but since they change `checkedTrackIds` and `checkedTypes` they cause some values to recompute again even though the values haven't changed.

They have changed though because the `updateSubset` function will create a new memory location with the same data even if nothing changes.  If we update this to prevent the `checkedTrackIds` and `checkedTypes` from updating it will prevent the second cascade unless those values truly do change.

I did this my simply removing the `Readonly` from the input on the `updateSubset`.  It shouldn't matter because the input is the value we are setting outside the function anyways.  It now checks to see if there are different items between the two arrays and if not it will directly return the old value preventing the other dependent computed/watcher methods from executing and allowing only one frame of update directly after editing an object.