### PR TITLE
Enhancement/minor changes

### DIFF
--- a/client/src/use/useTrackSelectionControls.spec.ts
+++ b/client/src/use/useTrackSelectionControls.spec.ts
@@ -31,18 +31,17 @@ describe('useTrackSelectionControls', () => {
     const trackIds = ref([0, 2, 200, 1000]);
     const tsc = useTrackSelectionControls({ trackIds });
 
-    tsc.selectNextTrack();
-    expect(tsc.selectedTrackId.value).toBe(0);
-    tsc.selectNextTrack();
-    expect(tsc.selectedTrackId.value).toBe(2);
+    expect(tsc.selectNextTrack()).toBe(0);
 
-    tsc.selectNextTrack(-100);
-    expect(tsc.selectedTrackId.value).toBeNull();
+    tsc.selectTrack(tsc.selectNextTrack());
+    expect(tsc.selectNextTrack()).toBe(2);
 
-    tsc.selectNextTrack(100);
-    expect(tsc.selectedTrackId.value).toBe(0);
+    expect(tsc.selectNextTrack(-100)).toBeNull();
+    tsc.selectTrack(tsc.selectNextTrack(-100));
 
-    tsc.selectNextTrack(100);
-    expect(tsc.selectedTrackId.value).toBeNull();
+    expect(tsc.selectNextTrack(100)).toBe(0);
+    tsc.selectTrack(tsc.selectNextTrack(100));
+
+    expect(tsc.selectNextTrack(100)).toBeNull();
   });
 });

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -26,10 +26,10 @@ export default function useTrackSelectionControls(
   function selectNextTrack(delta = 1): TrackId | null {
     if (trackIds.value.length > 0) {
       if (selectedTrackId.value === null) {
-        // if no track is selected, select the first one
+        // if no track is selected, return the first trackId
         return trackIds.value[0];
       }
-      // else select the next, and loop back to beginnng
+      // return the trackId by the delta offset if it exists
       const index = trackIds.value.indexOf(selectedTrackId.value);
       const newIndex = index + delta;
       if (newIndex >= 0 && newIndex < trackIds.value.length) {

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -27,8 +27,7 @@ export default function useTrackSelectionControls(
     if (trackIds.value.length > 0) {
       if (selectedTrackId.value === null) {
         // if no track is selected, select the first one
-        const [first] = trackIds.value;
-        return first;
+        return trackIds.value[0];
       }
       // else select the next, and loop back to beginnng
       const index = trackIds.value.indexOf(selectedTrackId.value);

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -23,25 +23,23 @@ export default function useTrackSelectionControls(
   /* default to index + 1
    * call with -1 to select previous, or pass any other delta
    */
-  function selectNextTrack(delta = 1) {
+  function selectNextTrack(delta = 1): TrackId | null {
     if (trackIds.value.length > 0) {
       if (selectedTrackId.value === null) {
         // if no track is selected, select the first one
-        [selectedTrackId.value] = trackIds.value;
-      } else {
-        // else select the next, and loop back to beginnng
-        const index = trackIds.value.indexOf(selectedTrackId.value);
-        const newIndex = index + delta;
-        if (newIndex >= 0 && newIndex < trackIds.value.length) {
-          // if we are not at the end
-          selectedTrackId.value = trackIds.value[newIndex];
-        } else {
-          selectTrack(null, false);
-        }
+        const [first] = trackIds.value;
+        return first;
       }
-    } else {
-      selectTrack(null, false);
+      // else select the next, and loop back to beginnng
+      const index = trackIds.value.indexOf(selectedTrackId.value);
+      const newIndex = index + delta;
+      if (newIndex >= 0 && newIndex < trackIds.value.length) {
+        // if we are not at the end
+        return trackIds.value[newIndex];
+      }
     }
+    //Return null if no other conditions are met
+    return null;
   }
   return {
     selectedTrackId,

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -147,9 +147,9 @@ export default defineComponent({
       }
       // if removed track was selected, unselect before remove
       if (selectedTrackId.value === trackId) {
-        selectNextTrack(1);
-        if (editingTrack.value) {
-          selectTrack(selectedTrackId.value, false);
+        const newTrack = selectNextTrack(1) !== null ? selectNextTrack(1) : selectNextTrack(-1);
+        if (newTrack !== null) {
+          selectTrack(newTrack, false);
         }
       }
       tsRemoveTrack(trackId);
@@ -181,11 +181,14 @@ export default defineComponent({
 
     //Selection of next track while seeking to position
     function handleSelectNext(delta: number) {
-      selectNextTrack(delta);
-      if (selectedTrackId.value !== null) {
-        const track = trackMap.get(selectedTrackId.value);
-        if (track !== undefined) {
-          playbackComponent.value.seek(track.begin);
+      const newTrack = selectNextTrack(delta);
+      if (newTrack !== null) {
+        selectTrack(newTrack, false);
+        if (selectedTrackId.value !== null) {
+          const track = trackMap.get(selectedTrackId.value);
+          if (track !== undefined) {
+            playbackComponent.value.seek(track.begin);
+          }
         }
       }
     }

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -212,7 +212,6 @@ export default defineComponent({
       handleTrackEdit,
       removeTrack,
       save,
-      selectNextTrack,
       selectTrack,
       toggleFeaturePointing,
       featurePointed,

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -184,14 +184,15 @@ export default defineComponent({
       const newTrack = selectNextTrack(delta);
       if (newTrack !== null) {
         selectTrack(newTrack, false);
-        if (selectedTrackId.value !== null) {
-          const track = trackMap.get(selectedTrackId.value);
-          if (track !== undefined) {
-            playbackComponent.value.seek(track.begin);
-          }
+        const track = trackMap.get(newTrack);
+        if (track === undefined) {
+          throw new Error(`Accessed missing track ${newTrack}`);
+        } else {
+          playbackComponent.value.seek(track.begin);
         }
       }
     }
+
 
     return {
       /* props use locally */

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -148,6 +148,9 @@ export default defineComponent({
       // if removed track was selected, unselect before remove
       if (selectedTrackId.value === trackId) {
         selectNextTrack(1);
+        if (editingTrack.value) {
+          selectTrack(selectedTrackId.value, false);
+        }
       }
       tsRemoveTrack(trackId);
     }
@@ -176,6 +179,17 @@ export default defineComponent({
       }
     }
 
+    //Selection of next track while seeking to position
+    function handleSelectNext(delta: number) {
+      selectNextTrack(delta);
+      if (selectedTrackId.value !== null) {
+        const track = trackMap.get(selectedTrackId.value);
+        if (track !== undefined) {
+          playbackComponent.value.seek(track.begin);
+        }
+      }
+    }
+
     return {
       /* props use locally */
       annotatorType,
@@ -194,6 +208,7 @@ export default defineComponent({
       addTrack,
       deleteFeaturePoints,
       handleTrackClick,
+      handleSelectNext,
       handleTrackEdit,
       removeTrack,
       save,
@@ -291,8 +306,8 @@ export default defineComponent({
         @track-remove="removeTrack"
         @track-click="handleTrackClick"
         @track-edit="handleTrackEdit"
-        @track-next="selectNextTrack(1)"
-        @track-previous="selectNextTrack(-1)"
+        @track-next="handleSelectNext(1)"
+        @track-previous="handleSelectNext(-1)"
       >
         <ConfidenceFilter :confidence.sync="confidenceThreshold" />
       </sidebar>


### PR DESCRIPTION
Swaps the `selectNextTrack` function to return a trackId instead of manually setting the track.  This allows external functions a little bit more control over how the switching occurs between tracks.  It fixes the following:

- Now when deleting tracks we can deselect edit mode where as before we would of had to make a second call to `selectTrack` with the current `selectedTrackId.value`
- When using keyboard controls it now properly can use the `seek` feature to go to the first frame.  This was some specifically Matt asked for with the keyboard controls.
- When deleting previously we selected the next track ID in the list.  If you were at the end, it would select null.  Now it tries tot select the next, if it doesn't exist it will select the previous.
- When using keyboard controls if you held up the first selected track would flash between `null` and the first track.  That no longer occurs, but we don't have wrapping of the track.  That can be done if required in the `handleSelectNext` function if we want to add in wrapping.  
- NOTE: selectNextTrack no now longer maintains the edit state, but that can be easily changed in the `handleSelectNext` function now in viewer.