### PR TITLE
Ui/change colors

### DIFF
--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -40,8 +40,8 @@ export default Vue.extend({
       type: Object as PropType<Ref<boolean>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<(t: string) => string>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
   },
@@ -128,7 +128,7 @@ export default Vue.extend({
         inputValue: checkedTrackIds.indexOf(trackId) >= 0,
         selected: selectedTrackId === trackId,
         editingTrack,
-        color: this.typeColorMapper(trackType),
+        color: this.typeStyling.value.color(trackType),
         types: allTypes,
         splittable: track.length > 1,
       };

--- a/client/src/components/layers/AnnotationLayer.ts
+++ b/client/src/components/layers/AnnotationLayer.ts
@@ -78,9 +78,9 @@ export default class AnnotationLayer extends BaseLayer<RectGeoJSData> {
           return this.stateStyling.selected.color;
         }
         if (data.confidencePairs) {
-          return this.typeColorMap(data.confidencePairs[0]);
+          return this.typeStyling.value.color(data.confidencePairs[0]);
         }
-        return this.typeColorMap.range()[0];
+        return this.typeStyling.value.color('');
       },
       strokeOpacity: (_point, _index, data) => {
         if (data.selected) {

--- a/client/src/components/layers/BaseLayer.ts
+++ b/client/src/components/layers/BaseLayer.ts
@@ -3,6 +3,7 @@ import { Annotator } from '@/components/annotators/annotatorType';
 import { FrameDataTrack } from '@/components/layers/LayerTypes';
 import { StateStyles } from '@/use/useStyling';
 import Vue from 'vue';
+import { Ref } from '@vue/composition-api';
 
 // eslint-disable-next-line max-len
 export type StyleFunction<T, D> = T | ((point: [number, number], index: number, data: D) => T | undefined);
@@ -24,7 +25,7 @@ export interface BaseLayerParams {
     frameData?: FrameDataTrack;
     annotator: Annotator;
     stateStyling: StateStyles;
-    typeColorMap: d3.ScaleOrdinal<string, string>;
+    typeStyling: Ref<{ color: (type: string) => string }>;
 }
 
 export default abstract class BaseLayer<D> extends Vue {
@@ -36,7 +37,7 @@ export default abstract class BaseLayer<D> extends Vue {
 
     style: LayerStyle<D>;
 
-    typeColorMap: d3.ScaleOrdinal<string, string>;
+    typeStyling: Ref<{ color: (type: string) => string }>;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     featureLayer: any;
@@ -47,12 +48,12 @@ export default abstract class BaseLayer<D> extends Vue {
     constructor({
       annotator,
       stateStyling,
-      typeColorMap,
+      typeStyling,
     }: BaseLayerParams) {
       super();
       this.annotator = annotator;
       this.stateStyling = stateStyling;
-      this.typeColorMap = typeColorMap;
+      this.typeStyling = typeStyling;
       this.formattedData = [];
       this.style = {};
       this.featureLayer = null;

--- a/client/src/components/layers/TextLayer.ts
+++ b/client/src/components/layers/TextLayer.ts
@@ -64,11 +64,11 @@ export default class TextLayer extends BaseLayer<TextData> {
             if (this.stateStyling.disabled.color !== 'type') {
               return this.stateStyling.disabled.color;
             }
-            return this.typeColorMap(data.type);
+            return this.typeStyling.value.color(data.type);
           }
           return this.stateStyling.selected.color;
         }
-        return this.typeColorMap(data.type);
+        return this.typeStyling.value.color(data.type);
       },
       offset: (data) => ({
         x: data.offsetY || 3,

--- a/client/src/lib/api/viame.service.ts
+++ b/client/src/lib/api/viame.service.ts
@@ -93,6 +93,12 @@ function setMetadataForItem(itemId: string, metadata: object) {
     metadata,
   );
 }
+function setMetadataForFolder(folderId: string, metadata: object) {
+  return girderRest.put(
+    `/folder/${folderId}/metadata?allowNull=true`,
+    metadata,
+  );
+}
 
 export {
   Attribute,
@@ -105,4 +111,5 @@ export {
   runVideoConversion,
   runPipeline,
   setMetadataForItem,
+  setMetadataForFolder,
 };

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -7,7 +7,7 @@ interface EventChartParams {
   enabledTrackIds: Readonly<Ref<readonly TrackId[]>>;
   selectedTrackId: Ref<TrackId | null>;
   trackMap: Map<TrackId, Track>;
-  typeColorMapper: (type: string) => string;
+  typeStyling: Ref<{ color: (type: string) => string }>;
 }
 
 interface EventChartData {
@@ -19,10 +19,11 @@ interface EventChartData {
 }
 
 export default function useEventChart({
-  enabledTrackIds, selectedTrackId, trackMap, typeColorMapper,
+  enabledTrackIds, selectedTrackId, trackMap, typeStyling,
 }: EventChartParams) {
   const eventChartData = computed(() => {
     const values = [] as EventChartData[];
+    const mapfunc = typeStyling.value.color;
     /* use forEach rather than filter().map() to save an interation */
     enabledTrackIds.value.forEach((trackId) => {
       const track = trackMap.get(trackId);
@@ -35,7 +36,7 @@ export default function useEventChart({
         values.push({
           trackId,
           name: `Track ${trackId}`,
-          color: typeColorMapper(trackType),
+          color: mapfunc(trackType),
           selected: trackId === selectedTrackId.value,
           range: [track.begin, track.end],
         });

--- a/client/src/use/useGirderDataset.ts
+++ b/client/src/use/useGirderDataset.ts
@@ -12,6 +12,7 @@ interface VIIMEDataset extends GirderModel {
   meta: {
     type: 'video' | 'image-sequence';
     fps: number;
+    customTypeColors?: Record<string, string>;
   };
 }
 
@@ -19,7 +20,6 @@ export default function useGirderDataset() {
   const dataset = ref(null as VIIMEDataset | null);
   const imageUrls = ref([] as string[]);
   const videoUrl = ref('');
-
   const frameRate = computed(() => (dataset.value && dataset.value.meta.fps as number)
     || defaultFrameRate);
 
@@ -72,6 +72,7 @@ export default function useGirderDataset() {
       throw new Error(`could not fetch dataset for id ${datasetId}`);
     }
     dataset.value = folder;
+    return dataset.value;
   }
 
   return {

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -3,7 +3,7 @@ import Track, { TrackId } from '@/lib/track';
 
 interface UseLineChartParams {
   enabledTrackIds: Readonly<Ref<readonly TrackId[]>>;
-  typeColorMapper: (type: string) => unknown;
+  typeStyling: Ref<{ color: (type: string) => string }>;
   trackMap: Map<TrackId, Track>;
   allTypes: Readonly<Ref<readonly string[]>>;
 }
@@ -25,7 +25,7 @@ function updateHistogram(begin: number, end: number, histogram: number[]) {
 
 export default function useLineChart({
   enabledTrackIds,
-  typeColorMapper,
+  typeStyling,
   trackMap,
   allTypes,
 }: UseLineChartParams) {
@@ -60,6 +60,7 @@ export default function useLineChart({
       }
     });
 
+    const mapfunc = typeStyling.value.color;
     /* Now, each histograms array looks like this:
      *   [1, 2, 0, -2, -1]
      * We want to accumulate each array left-to-right so it looks like this:
@@ -74,7 +75,7 @@ export default function useLineChart({
         }, 0);
         return {
           values: accumulatedHistogram,
-          color: type === 'total' ? 'lime' : typeColorMapper(type),
+          color: type === 'total' ? 'lime' : mapfunc(type),
           name: type,
         };
       }) as LineChartData[];

--- a/client/src/use/useSave.ts
+++ b/client/src/use/useSave.ts
@@ -17,5 +17,6 @@ export default function useSave() {
     pendingSaveCount.value += 1;
   }
 
+
   return { save, markChangesPending, pendingSaveCount };
 }

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -1,23 +1,32 @@
-import { inject } from '@vue/composition-api';
+import Vue from 'vue';
+import {
+  inject, ref, Ref, computed,
+} from '@vue/composition-api';
 import colors from 'vuetify/lib/util/colors';
 import * as d3 from 'd3';
 import { Vuetify } from 'vuetify';
+import { setMetadataForFolder } from '@/lib/api/viame.service';
 
-interface Style{
+interface Style {
   strokeWidth: number;
   opacity: number;
   color: string;
-
 }
+
 export interface StateStyles {
   standard: Style;
   selected: Style;
   disabled: Style;
 }
 
+interface UseStylingParams {
+  markChangesPending: () => void;
+}
 
-export default function useStyling() {
+
+export default function useStyling({ markChangesPending }: UseStylingParams) {
   const vuetify = inject('vuetify') as Vuetify;
+  const customColors: Ref<Record<string, string>> = ref({});
   if (!vuetify) {
     throw new Error('Missing vuetify provide/inject');
   }
@@ -50,6 +59,58 @@ export default function useStyling() {
     colors.purple.darken3,
     colors.green.darken3,
   ];
-  const typeColorMapper = d3.scaleOrdinal().range(typeColors) as (t: string) => string;
-  return { stateStyling, typeColorMapper };
+
+  function loadTypeColors(list?: Record<string, string>) {
+    if (list) {
+      // Copy over the item so they can be modified in future
+      Object.entries(list).forEach(([key, value]) => {
+        Vue.set(customColors.value, key, value);
+      });
+    }
+  }
+
+  function updateTypeColor({ type, color }: { type: string; color: string }) {
+    Vue.set(customColors.value, type, color);
+    markChangesPending();
+  }
+
+  const ordinalColorMapper = d3.scaleOrdinal<string>().range(typeColors);
+  const typeStyling = computed(() => {
+    const _customColors = customColors.value;
+    return {
+      color: (type: string) => {
+        if (_customColors[type]) {
+          return _customColors[type];
+        }
+        if (type === '') {
+          return ordinalColorMapper.range()[0];
+        }
+        return ordinalColorMapper(type);
+      },
+    };
+  });
+
+  async function saveTypeColors(
+    datasetId: string,
+    allTypes: Ref<readonly string[]>,
+  ) {
+    //We need to remove any unused types in the colors, either deleted or changed
+    //Also want to save default colors for reloading
+    const savedTypeColors: Record<string, string> = {};
+    allTypes.value.forEach((name) => {
+      if (!savedTypeColors[name] && customColors.value[name]) {
+        savedTypeColors[name] = customColors.value[name];
+      } else if (!savedTypeColors[name]) { // Also save ordinal Colors as well
+        savedTypeColors[name] = typeStyling.value.color(name);
+      }
+    });
+
+    await setMetadataForFolder(datasetId, {
+      customTypeColors: savedTypeColors,
+    });
+  }
+
+  return {
+    stateStyling, typeStyling, updateTypeColor, loadTypeColors, saveTypeColors,
+  };
 }

--- a/client/src/use/useTrackFilters.ts
+++ b/client/src/use/useTrackFilters.ts
@@ -86,6 +86,21 @@ export default function useFilteredTracks(
     }
   });
 
+  function updateTypeName({ currentType, newType }: {currentType: string; newType: string}) {
+    //Go through the entire list and replace the oldType with the new Type
+    sortedTrackIds.value.forEach((trackId) => {
+      const track = trackMap.get(trackId);
+      if (track === undefined) {
+        throw new Error(`Accessed missing track ${trackId}`);
+      }
+      track.confidencePairs.forEach(([name]) => {
+        if (name === currentType) {
+          track.setType(newType);
+        }
+      });
+    });
+  }
+
   return {
     checkedTrackIds,
     checkedTypes,
@@ -93,5 +108,6 @@ export default function useFilteredTracks(
     allTypes,
     filteredTrackIds,
     enabledTrackIds,
+    updateTypeName,
   };
 }

--- a/client/src/views/TrackViewer/Layers.vue
+++ b/client/src/views/TrackViewer/Layers.vue
@@ -43,8 +43,8 @@ export default defineComponent({
       type: Object as PropType<Ref<boolean>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<d3.ScaleOrdinal<string, string>>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
     stateStyling: {
@@ -69,25 +69,25 @@ export default defineComponent({
     const annotationLayer = new AnnotationLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
     });
     const textLayer = new TextLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
     });
 
     const editAnnotationLayer = new EditAnnotationLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
       editing: 'rectangle',
     });
 
     const markerEditLayer = new EditAnnotationLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
       editing: 'point',
     });
 
@@ -95,7 +95,7 @@ export default defineComponent({
     const markerLayer = new MarkerLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
     });
 
     function updateLayers() {

--- a/client/src/views/TrackViewer/Sidebar.vue
+++ b/client/src/views/TrackViewer/Sidebar.vue
@@ -46,8 +46,8 @@ export default defineComponent({
       type: Object as PropType<Ref<boolean>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<(t: string) => string>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
     width: {
@@ -117,6 +117,8 @@ export default defineComponent({
         <type-list
           v-bind="trackListProps"
           class="flex-shrink-1 flex-grow-1 typelist"
+          @update-type-color="$emit('update-type-color',$event)"
+          @update-type-name="$emit('update-type-name',$event)"
         />
         <slot />
         <v-spacer />


### PR DESCRIPTION
![Color Editing](https://user-images.githubusercontent.com/61746913/85297637-fea84980-b470-11ea-97e3-04e8a8a4e69a.gif)
Fixes #80 

Added in ability for users to edit types and have their own custom colors.  They can also edit type names.  Custom colors are saved in the meta data for the folder under `customTypeColors` and are a simple key/value pair for the type and the hex color code.

Chose to store the default colors as well if the user edits anything.  It seems like colors should be the same for all other items if the user refreshes the page.