### PR TITLE
Splittrack/prompt fix

### DIFF
--- a/client/src/lib/vue-utilities/prompt-service/Prompt.vue
+++ b/client/src/lib/vue-utilities/prompt-service/Prompt.vue
@@ -59,9 +59,9 @@ export default {
       <v-card-title
         v-if="title"
         v-mousetrap="[
-          { bind: 'left', handler: () => focus('negative') },
-          { bind: 'right', handler: () => focus('positive') },
-          { bind: 'enter', handler: () => select() },
+          { bind: 'left', handler: () => focus('negative'), disable: !show },
+          { bind: 'right', handler: () => focus('positive'), disable: !show },
+          { bind: 'enter', handler: () => select(), disable: !show },
         ]"
         class="title"
       >

--- a/client/src/lib/vue-utilities/prompt-service/Prompt.vue
+++ b/client/src/lib/vue-utilities/prompt-service/Prompt.vue
@@ -19,6 +19,7 @@ export default {
         this.resolve(false);
       } else {
         // Needs to mount and then dialog transition, single tick doesn't work
+        this.selected = 'positive';
         this.$nextTick(() => this.$nextTick(() => this.$refs.positive.$el.focus()));
       }
     },


### PR DESCRIPTION
Extremely small fix to an issue I noticed while testing the Split Track.  Issue would be if you open up a prompt, close it, then hit left key.  Then open a new prompt to delete again. This will just ensure that the positive item is selected each time the prompt comes up.  Also prevents the handlers from executing if the prompt isn't visible.