### PR TITLE
Refactor reactive typeColorMapper

### DIFF
--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -40,8 +40,8 @@ export default Vue.extend({
       type: Object as PropType<Ref<boolean>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<(t: string) => string>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
   },
@@ -128,7 +128,7 @@ export default Vue.extend({
         inputValue: checkedTrackIds.indexOf(trackId) >= 0,
         selected: selectedTrackId === trackId,
         editingTrack,
-        color: this.typeColorMapper(trackType),
+        color: this.typeStyling.value.color(trackType),
         types: allTypes,
       };
     },

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -14,8 +14,8 @@ export default Vue.extend({
       type: Object as PropType<Ref<string[]>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<(t: string) => string>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
   },
@@ -33,7 +33,7 @@ export default Vue.extend({
       this.selectedType = type;
       this.editingType = this.selectedType;
       this.showPicker = true;
-      this.selectedColor = this.typeColorMapper(type);
+      this.selectedColor = this.typeStyling.value.color(type);
       this.editingColor = this.selectedColor;
     },
     acceptChanges() {
@@ -74,12 +74,12 @@ export default Vue.extend({
           <v-checkbox
             v-model="checkedTypes.value"
             :value="type"
-            :color="typeColorMapper(type)"
+            :color="typeStyling.value.color(type)"
             :label="type"
             dense
             shrink
             hide-details
-            class="my-1 ml-3 typeCheckBox"
+            class="my-1 ml-3 type-checkbox"
           />
           <v-spacer />
           <v-tooltip
@@ -111,25 +111,11 @@ export default Vue.extend({
       width="350"
     >
       <div
-        class="typeEdit"
+        class="type-edit"
       >
         <v-card>
           <v-card-title>
             Editing Type
-            <v-spacer />
-            <v-spacer />
-            <v-btn
-              class="mr-1"
-              icon
-              small
-              @click="showPicker = false"
-            >
-              <v-icon
-                small
-              >
-                mdi-close
-              </v-icon>
-            </v-btn>
           </v-card-title>
           <v-card-subtitle class="my-0 py-0">
             <v-container class="py-0">
@@ -174,11 +160,18 @@ export default Vue.extend({
           <v-card-actions>
             <v-spacer />
             <v-btn
-              color="primary"
+              depressed=""
               text
+              @click="showPicker = false"
+            >
+              Cancel
+            </v-btn>
+            <v-btn
+              color="primary"
+              depressed
               @click="acceptChanges"
             >
-              OK
+              Save
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -187,18 +180,21 @@ export default Vue.extend({
   </div>
 </template>
 
-<style lang='scss'>
-.typeEdit{
+<style scoped lang='scss'>
+.type-edit{
   overflow: hidden;
 }
-.typeCheckBox{
-max-width: 80%;
-overflow:hidden;
+
+.type-checkbox{
+  max-width: 80%;
+  overflow:hidden;
 }
+
 .hover-show-parent {
   .hover-show-child {
     display: none;
   }
+
   &:hover {
     .hover-show-child {
       display: inherit;

--- a/client/src/components/layers/AnnotationLayer.ts
+++ b/client/src/components/layers/AnnotationLayer.ts
@@ -78,9 +78,9 @@ export default class AnnotationLayer extends BaseLayer<RectGeoJSData> {
           return this.stateStyling.selected.color;
         }
         if (data.confidencePairs) {
-          return this.typeColorMap(data.confidencePairs[0]);
+          return this.typeStyling.value.color(data.confidencePairs[0]);
         }
-        return this.typeColorMap.range()[0];
+        return this.typeStyling.value.color('');
       },
       strokeOpacity: (_point, _index, data) => {
         if (data.selected) {

--- a/client/src/components/layers/BaseLayer.ts
+++ b/client/src/components/layers/BaseLayer.ts
@@ -3,6 +3,7 @@ import { Annotator } from '@/components/annotators/annotatorType';
 import { FrameDataTrack } from '@/components/layers/LayerTypes';
 import { StateStyles } from '@/use/useStyling';
 import Vue from 'vue';
+import { Ref } from '@vue/composition-api';
 
 // eslint-disable-next-line max-len
 export type StyleFunction<T, D> = T | ((point: [number, number], index: number, data: D) => T | undefined);
@@ -24,7 +25,7 @@ export interface BaseLayerParams {
     frameData?: FrameDataTrack;
     annotator: Annotator;
     stateStyling: StateStyles;
-    typeColorMap: d3.ScaleOrdinal<string, string>;
+    typeStyling: Ref<{ color: (type: string) => string }>;
 }
 
 export default abstract class BaseLayer<D> extends Vue {
@@ -36,7 +37,7 @@ export default abstract class BaseLayer<D> extends Vue {
 
     style: LayerStyle<D>;
 
-    typeColorMap: d3.ScaleOrdinal<string, string>;
+    typeStyling: Ref<{ color: (type: string) => string }>;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     featureLayer: any;
@@ -47,12 +48,12 @@ export default abstract class BaseLayer<D> extends Vue {
     constructor({
       annotator,
       stateStyling,
-      typeColorMap,
+      typeStyling,
     }: BaseLayerParams) {
       super();
       this.annotator = annotator;
       this.stateStyling = stateStyling;
-      this.typeColorMap = typeColorMap;
+      this.typeStyling = typeStyling;
       this.formattedData = [];
       this.style = {};
       this.featureLayer = null;

--- a/client/src/components/layers/TextLayer.ts
+++ b/client/src/components/layers/TextLayer.ts
@@ -64,11 +64,11 @@ export default class TextLayer extends BaseLayer<TextData> {
             if (this.stateStyling.disabled.color !== 'type') {
               return this.stateStyling.disabled.color;
             }
-            return this.typeColorMap(data.type);
+            return this.typeStyling.value.color(data.type);
           }
           return this.stateStyling.selected.color;
         }
-        return this.typeColorMap(data.type);
+        return this.typeStyling.value.color(data.type);
       },
       offset: (data) => ({
         x: data.offsetY || 3,

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -7,7 +7,7 @@ interface EventChartParams {
   enabledTrackIds: Readonly<Ref<readonly TrackId[]>>;
   selectedTrackId: Ref<TrackId | null>;
   trackMap: Map<TrackId, Track>;
-  typeColorMapper: (type: string) => string;
+  typeStyling: Ref<{ color: (type: string) => string }>;
 }
 
 interface EventChartData {
@@ -19,10 +19,11 @@ interface EventChartData {
 }
 
 export default function useEventChart({
-  enabledTrackIds, selectedTrackId, trackMap, typeColorMapper,
+  enabledTrackIds, selectedTrackId, trackMap, typeStyling,
 }: EventChartParams) {
   const eventChartData = computed(() => {
     const values = [] as EventChartData[];
+    const mapfunc = typeStyling.value.color;
     /* use forEach rather than filter().map() to save an interation */
     enabledTrackIds.value.forEach((trackId) => {
       const track = trackMap.get(trackId);
@@ -35,7 +36,7 @@ export default function useEventChart({
         values.push({
           trackId,
           name: `Track ${trackId}`,
-          color: typeColorMapper(trackType),
+          color: mapfunc(trackType),
           selected: trackId === selectedTrackId.value,
           range: [track.begin, track.end],
         });

--- a/client/src/use/useGirderDataset.ts
+++ b/client/src/use/useGirderDataset.ts
@@ -72,7 +72,7 @@ export default function useGirderDataset() {
       throw new Error(`could not fetch dataset for id ${datasetId}`);
     }
     dataset.value = folder;
-    return dataset.value.meta;
+    return dataset.value;
   }
 
   return {

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -3,7 +3,7 @@ import Track, { TrackId } from '@/lib/track';
 
 interface UseLineChartParams {
   enabledTrackIds: Readonly<Ref<readonly TrackId[]>>;
-  typeColorMapper: (type: string) => unknown;
+  typeStyling: Ref<{ color: (type: string) => string }>;
   trackMap: Map<TrackId, Track>;
   allTypes: Readonly<Ref<readonly string[]>>;
 }
@@ -25,7 +25,7 @@ function updateHistogram(begin: number, end: number, histogram: number[]) {
 
 export default function useLineChart({
   enabledTrackIds,
-  typeColorMapper,
+  typeStyling,
   trackMap,
   allTypes,
 }: UseLineChartParams) {
@@ -60,6 +60,7 @@ export default function useLineChart({
       }
     });
 
+    const mapfunc = typeStyling.value.color;
     /* Now, each histograms array looks like this:
      *   [1, 2, 0, -2, -1]
      * We want to accumulate each array left-to-right so it looks like this:
@@ -74,7 +75,7 @@ export default function useLineChart({
         }, 0);
         return {
           values: accumulatedHistogram,
-          color: type === 'total' ? 'lime' : typeColorMapper(type),
+          color: type === 'total' ? 'lime' : mapfunc(type),
           name: type,
         };
       }) as LineChartData[];

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import {
   inject, ref, Ref, computed,
 } from '@vue/composition-api';
@@ -63,7 +64,7 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     if (list) {
       // Copy over the item so they can be modified in future
       Object.entries(list).forEach(([key, value]) => {
-        customColors.value[key] = value;
+        Vue.set(customColors.value, key, value);
       });
     }
   }

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -70,7 +70,7 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
   }
 
   function updateTypeColor({ type, color }: { type: string; color: string }) {
-    customColors.value[type] = color;
+    Vue.set(customColors.value, type, color);
     markChangesPending();
   }
 

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -1,15 +1,17 @@
-import { inject, ref, Ref } from '@vue/composition-api';
+import {
+  inject, ref, Ref, computed,
+} from '@vue/composition-api';
 import colors from 'vuetify/lib/util/colors';
 import * as d3 from 'd3';
 import { Vuetify } from 'vuetify';
 import { setMetadataForFolder } from '@/lib/api/viame.service';
 
-interface Style{
+interface Style {
   strokeWidth: number;
   opacity: number;
   color: string;
-
 }
+
 export interface StateStyles {
   standard: Style;
   selected: Style;
@@ -59,25 +61,33 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
 
   function loadTypeColors(list?: Record<string, string>) {
     if (list) {
-    // Copy over the item so they can be modified in future
+      // Copy over the item so they can be modified in future
       Object.entries(list).forEach(([key, value]) => {
         customColors.value[key] = value;
       });
     }
   }
 
-  function updateTypeColor({ type, color }: {type: string; color: string}) {
+  function updateTypeColor({ type, color }: { type: string; color: string }) {
     customColors.value[type] = color;
     markChangesPending();
   }
 
-  const ordinalColorMapper = d3.scaleOrdinal().range(typeColors) as (t: string) => string;
-  const typeColorMapper = (type: string) => {
-    if (customColors.value[type]) {
-      return customColors.value[type];
-    }
-    return ordinalColorMapper(type);
-  };
+  const ordinalColorMapper = d3.scaleOrdinal<string>().range(typeColors);
+  const typeStyling = computed(() => {
+    const _customColors = customColors.value;
+    return {
+      color: (type: string) => {
+        if (_customColors[type]) {
+          return _customColors[type];
+        }
+        if (type === '') {
+          return ordinalColorMapper.range()[0];
+        }
+        return ordinalColorMapper(type);
+      },
+    };
+  });
 
   async function saveTypeColors(
     datasetId: string,
@@ -85,12 +95,12 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
   ) {
     //We need to remove any unused types in the colors, either deleted or changed
     //Also want to save default colors for reloading
-    const savedTypeColors: Record<string, string> = { };
+    const savedTypeColors: Record<string, string> = {};
     allTypes.value.forEach((name) => {
       if (!savedTypeColors[name] && customColors.value[name]) {
         savedTypeColors[name] = customColors.value[name];
       } else if (!savedTypeColors[name]) { // Also save ordinal Colors as well
-        savedTypeColors[name] = typeColorMapper(name);
+        savedTypeColors[name] = typeStyling.value.color(name);
       }
     });
 
@@ -100,6 +110,6 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
   }
 
   return {
-    stateStyling, typeColorMapper, updateTypeColor, loadTypeColors, saveTypeColors,
+    stateStyling, typeStyling, updateTypeColor, loadTypeColors, saveTypeColors,
   };
 }

--- a/client/src/views/TrackViewer/Layers.vue
+++ b/client/src/views/TrackViewer/Layers.vue
@@ -186,7 +186,6 @@ export default defineComponent({
       props.editingTrack,
       props.selectedTrackId,
       props.featurePointing,
-      props.typeStyling,
     ], () => {
       updateLayers();
     });

--- a/client/src/views/TrackViewer/Layers.vue
+++ b/client/src/views/TrackViewer/Layers.vue
@@ -43,8 +43,8 @@ export default defineComponent({
       type: Object as PropType<Ref<boolean>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<d3.ScaleOrdinal<string, string>>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
     stateStyling: {
@@ -69,25 +69,25 @@ export default defineComponent({
     const annotationLayer = new AnnotationLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
     });
     const textLayer = new TextLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
     });
 
     const editAnnotationLayer = new EditAnnotationLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
       editing: 'rectangle',
     });
 
     const markerEditLayer = new EditAnnotationLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
       editing: 'point',
     });
 
@@ -95,7 +95,7 @@ export default defineComponent({
     const markerLayer = new MarkerLayer({
       annotator,
       stateStyling: props.stateStyling,
-      typeColorMap: props.typeColorMapper,
+      typeStyling: props.typeStyling,
     });
 
     function updateLayers() {
@@ -186,6 +186,7 @@ export default defineComponent({
       props.editingTrack,
       props.selectedTrackId,
       props.featurePointing,
+      props.typeStyling,
     ], () => {
       updateLayers();
     });

--- a/client/src/views/TrackViewer/Sidebar.vue
+++ b/client/src/views/TrackViewer/Sidebar.vue
@@ -46,8 +46,8 @@ export default defineComponent({
       type: Object as PropType<Ref<boolean>>,
       required: true,
     },
-    typeColorMapper: {
-      type: Function as PropType<(t: string) => string>,
+    typeStyling: {
+      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
       required: true,
     },
     width: {

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -73,7 +73,7 @@ export default defineComponent({
     } = useSave();
 
     const {
-      typeColorMapper,
+      typeStyling,
       stateStyling,
       updateTypeColor,
       loadTypeColors,
@@ -109,13 +109,16 @@ export default defineComponent({
       updateTypeName,
     } = useTrackFilters({ trackMap, sortedTrackIds });
 
-    // Initialize the view
     Promise.all([
-      loadDataset(datasetId).then((meta) => { loadTypeColors(meta && meta.customTypeColors); }),
+      loadDataset(datasetId),
       loadTracks(datasetId),
     ]).catch((err) => {
       // TODO p2: alert on errors...
       console.error(err);
+      throw err;
+    }).then(() => {
+      // tasks to run after dataset and tracks have loaded
+      loadTypeColors(dataset.value?.meta.customTypeColors);
     });
 
     const {
@@ -136,11 +139,11 @@ export default defineComponent({
     } = useFeaturePointing({ selectedTrackId, trackMap });
 
     const { lineChartData } = useLineChart({
-      enabledTrackIds, typeColorMapper, allTypes, trackMap,
+      enabledTrackIds, typeStyling, allTypes, trackMap,
     });
 
     const { eventChartData } = useEventChart({
-      enabledTrackIds, selectedTrackId, typeColorMapper, trackMap,
+      enabledTrackIds, selectedTrackId, typeStyling, trackMap,
     });
 
     const location = computed(() => store.state.location);
@@ -225,6 +228,8 @@ export default defineComponent({
       selectTrack,
       toggleFeaturePointing,
       featurePointed,
+      updateTypeColor,
+      updateTypeName,
       /* props for sub-components */
       controlsContainerProps: {
         lineChartData,
@@ -239,21 +244,19 @@ export default defineComponent({
         checkedTrackIds,
         selectedTrackId,
         editingTrack,
-        typeColorMapper,
+        typeStyling,
       },
       layerProps: {
         trackMap,
         trackIds: enabledTrackIds,
         selectedTrackId,
         editingTrack,
-        typeColorMapper,
+        typeStyling,
         stateStyling,
         intervalTree,
         featurePointing,
         featurePointingTarget,
       },
-      updateTypeColor,
-      updateTypeName,
     };
   },
 });


### PR DESCRIPTION
* Refactor `typeColorMapper` into more generic `typeStyling` object with coloring function
* Rename that everywher
* Make it reactive, depend on it for other UI componnets.
* Address other style comments from main PR.