### PR TITLE
Fix location errors

### DIFF
--- a/client/src/@types/girder-components.d.ts
+++ b/client/src/@types/girder-components.d.ts
@@ -6,6 +6,8 @@ declare module '@girder/components/src' {
     name: string;
     _id: string;
     _modelType: 'item' | 'folder' | 'file' | 'user';
+    parentCollection?: string;
+    parentId?: string;
     meta: { [key: string]: unknown };
   }
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -28,7 +28,7 @@ function getPathFromLocation(location: Location) {
   if (!location) {
     return '/';
   }
-  if (location.type) {
+  if (location.type && !location._modelType) {
     return `/${location.type}`;
   }
   return `/${location._modelType}${

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -87,9 +87,6 @@ export default {
   beforeDestroy() {
     this.notificationBus.$off('message:job_status', this.handleNotification);
   },
-  beforeRouteUpdate(to, from, next) {
-    next();
-  },
   methods: {
     ...mapMutations('Location', ['setLocation']),
     handleNotification() {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapState, mapMutations } from 'vuex';
+import { mapMutations } from 'vuex';
 import { FileManager } from '@girder/components/src/components/Snippet';
 import { getLocationType } from '@girder/components/src/utils';
 
@@ -33,11 +33,11 @@ export default {
     uploading: false,
   }),
   computed: {
-    ...mapState('Location', ['location']),
+    //...mapState('Location', ['location']),
 
     location: {
       get() {
-        return this.location_;
+        return this.$store.state.Location.location;
       },
       set(value) {
         this.location_ = value;
@@ -89,6 +89,7 @@ export default {
   },
   beforeRouteUpdate(to, from, next) {
     this.location_ = getLocationFromRoute(to);
+    this.setLocation(this.location_);
     next();
   },
   methods: {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -27,20 +27,21 @@ export default {
   },
   inject: ['notificationBus'],
   data: () => ({
-    location_: null,
     uploaderDialog: false,
     selected: [],
     uploading: false,
   }),
   computed: {
-    //...mapState('Location', ['location']),
 
     location: {
       get() {
         return this.$store.state.Location.location;
       },
+      /**
+       * This setter is used by Girder Web Components to set the location when it changes
+       * by clicking on a Breadcrumb link
+       */
       set(value) {
-        this.location_ = value;
         const newPath = getPathFromLocation(value);
         if (this.$route.path !== newPath) {
           this.$router.push(newPath);
@@ -80,16 +81,13 @@ export default {
     },
   },
   created() {
-    this.location_ = getLocationFromRoute(this.$route);
-    this.setLocation(this.location_);
+    this.setLocation(getLocationFromRoute(this.$route));
     this.notificationBus.$on('message:job_status', this.handleNotification);
   },
   beforeDestroy() {
     this.notificationBus.$off('message:job_status', this.handleNotification);
   },
   beforeRouteUpdate(to, from, next) {
-    this.location_ = getLocationFromRoute(to);
-    this.setLocation(this.location_);
     next();
   },
   methods: {

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -132,7 +132,7 @@ export default defineComponent({
     }).then(() => {
       // tasks to run after dataset and tracks have loaded
       loadTypeColors(dataset.value?.meta.customTypeColors);
-      if (location.value === null) {
+      if (!location.value) {
         updateLocation();
       }
     });

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import {
-  computed,
   defineComponent,
   ref,
 } from '@vue/composition-api';
@@ -111,6 +110,18 @@ export default defineComponent({
       updateTypeName,
     } = useTrackFilters({ trackMap, sortedTrackIds });
 
+    const location = ref(ctx.root.$store.state.Location.location);
+
+    function updateLocation() {
+      if (dataset.value && dataset.value.parentId && dataset.value.parentCollection) {
+        location.value = {
+          _id: dataset.value.parentId,
+          _modelType: dataset.value.parentCollection,
+        };
+        ctx.root.$store.commit('Location/setLocation', location.value);
+      }
+    }
+
     Promise.all([
       loadDataset(datasetId),
       loadTracks(datasetId),
@@ -121,6 +132,9 @@ export default defineComponent({
     }).then(() => {
       // tasks to run after dataset and tracks have loaded
       loadTypeColors(dataset.value?.meta.customTypeColors);
+      if (location.value === null) {
+        updateLocation();
+      }
     });
 
     const {
@@ -164,7 +178,6 @@ export default defineComponent({
       removeTrack,
     });
 
-    const location = computed(() => ctx.root.$store.state.Location.location);
 
     async function splitTracks(trackId: TrackId | undefined, _frame: number) {
       if (trackId) {


### PR DESCRIPTION
Fixes #187 
Fixes #188 

The location in the vuex state wasn't working properly with the breadcrumb bar in the file browser.  It required a click on which it would error and then a second click where it would finally change the page.  I updated Home.vue to get rid of the mapping of a location object while also having a computed location object.  This fix should make it work for all of the breadcrumb items as well as  utilizing the back/forward in the browser.

Additionally to this I modified the `Viewer.vue` to check and see if the state `location` variable is set.  If you navigate directly to an annotation link or if you refresh the page you reset and lose that `location` variable and when you click "Data" in the NavBar it takes you back to the root of girder.  I've updated it so it checks and sees if it has a location and if it doesn't it will calculate it from the returned girder folder and set the location as the parent folder.  This means that even refreshing or when provided a link clicking data should return you to the parent folder.  

To do this I added some items to the `GirderModel` interface to support `parentCollection, parentId`.  The data returned from `getFolder` should contain that data considering our annotations are always inside of a folder, although other times it won't have it if we are utilizing the breadcrumb.

