### PR TITLE
User Edited Type Styling

### DIFF
--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -155,17 +155,16 @@ export default Vue.extend({
                 />
               </v-col>
             </v-row>
-            <v-row>
+            <v-row dense>
               <v-col>
                 <v-text-field
                   v-model="editingThickness"
                   type="number"
                   :rules="[
-                    val => (val || '').length > 0 || 'This field is required'
+                    val => val >= 0 || 'Must be greater than 0'
                   ]"
                   required
                   label="Line Thickness"
-                  hide-details
                 />
               </v-col>
               <v-col>
@@ -179,30 +178,34 @@ export default Vue.extend({
                 />
               </v-col>
             </v-row>
-            <v-row>
+            <v-row dense>
               <v-col>
-                <v-slider
-                  v-model="editingOpacity"
-                  min="0.0"
-                  max="1.0"
-                  step="0.01"
-                  class="align-center"
-                  height="10"
-                  dense
-                  label="Opacity"
-                  hide-details
-                >
-                  <template v-slot:append>
-                    <v-text-field
-                      v-model="editingOpacity"
-                      class="mt-0 pt-0"
-                      hide-details
-                      single-line
-                      type="number"
-                      style="width: 60px"
-                    />
-                  </template>
-                </v-slider>
+                <v-row class="my-0">
+                  <v-slider
+                    v-model="editingOpacity"
+                    min="0.0"
+                    max="1.0"
+                    step="0.01"
+                    class="align-center"
+                    height="10"
+                    dense
+                    label="Opacity"
+                    hide-details
+                  >
+                    <template v-slot:append>
+                      <v-text-field
+                        v-model="editingOpacity"
+                        class="mt-0 pt-0"
+                        :rules="[
+                          val => ( val >= 0 && val <= 1)|| 'Must be between 0 and 1'
+                        ]"
+                        single-line
+                        type="number"
+                        style="width: 60px"
+                      />
+                    </template>
+                  </v-slider>
+                </v-row>
               </v-col>
             </v-row>
             <v-row

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -173,18 +173,6 @@ export default Vue.extend({
                 />
               </v-col>
               <v-col>
-                <v-text-field
-                  v-model="editingOpacity"
-                  type="number"
-                  :rules="[
-                    val => (val >= 0 && val <= 1) || 'This field is required'
-                  ]"
-                  required
-                  label="Opacity"
-                  hide-details
-                />
-              </v-col>
-              <v-col>
                 <v-checkbox
                   v-model="editingFill"
                   label="Fill"
@@ -193,6 +181,32 @@ export default Vue.extend({
                   hide-details
                   class="my-1 ml-3 type-checkbox"
                 />
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-slider
+                  v-model="editingOpacity"
+                  min="0.0"
+                  max="1.0"
+                  step="0.01"
+                  class="align-center"
+                  height="10"
+                  dense
+                  label="Opacity"
+                  hide-details
+                >
+                  <template v-slot:append>
+                    <v-text-field
+                      v-model="editingOpacity"
+                      class="mt-0 pt-0"
+                      hide-details
+                      single-line
+                      type="number"
+                      style="width: 60px"
+                    />
+                  </template>
+                </v-slider>
               </v-col>
             </v-row>
             <v-row

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -25,9 +25,6 @@ export default Vue.extend({
       showPicker: false,
       selectedColor: '',
       selectedType: '',
-      selectedThickness: 5,
-      selectedFill: false,
-      selectedOpacity: 1.0,
       editingType: '',
       editingColor: '',
       editingThickness: 5,
@@ -40,11 +37,10 @@ export default Vue.extend({
       this.selectedType = type;
       this.editingType = this.selectedType;
       this.showPicker = true;
-      this.selectedColor = this.typeStyling.value.color(type);
-      this.editingColor = this.selectedColor;
-      this.selectedThickness = this.typeStyling.value.strokeWidth(type);
-      this.selectedFill = this.typeStyling.value.fill(type);
-      this.selectedOpacity = this.typeStyling.value.opacity(type);
+      this.editingColor = this.typeStyling.value.color(type);
+      this.editingThickness = this.typeStyling.value.strokeWidth(type);
+      this.editingFill = this.typeStyling.value.fill(type);
+      this.editingOpacity = this.typeStyling.value.opacity(type);
     },
     acceptChanges() {
       this.showPicker = false;

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -30,6 +30,7 @@ export default Vue.extend({
       editingThickness: 5,
       editingFill: false,
       editingOpacity: 1.0,
+      valid: true,
     };
   },
   methods: {
@@ -74,45 +75,47 @@ export default Vue.extend({
     <v-subheader class="flex-shrink-0">
       Type Filter
     </v-subheader>
-    <div class="overflow-y-auto flex-grow-1">
-      <v-container>
+    <div class="overflow-y-auto">
+      <v-container class="py-2">
         <v-row
           v-for="type in allTypes.value"
           :key="type"
           class="hover-show-parent"
         >
-          <v-checkbox
-            v-model="checkedTypes.value"
-            :value="type"
-            :color="typeStyling.value.color(type)"
-            :label="type"
-            dense
-            shrink
-            hide-details
-            class="my-1 ml-3 type-checkbox"
-          />
-          <v-spacer />
-          <v-tooltip
-            open-delay="100"
-            bottom
-          >
-            <template #activator="{ on }">
-              <v-btn
-                class="mr-1 hover-show-child"
-                icon
-                small
-                v-on="on"
-                @click="clickEdit(type)"
-              >
-                <v-icon
+          <v-col class="d-flex flex-row align-center py-0">
+            <v-checkbox
+              v-model="checkedTypes.value"
+              :value="type"
+              :color="typeStyling.value.color(type)"
+              :label="type"
+              dense
+              shrink
+              hide-details
+              class="my-1 type-checkbox"
+            />
+            <v-spacer />
+            <v-tooltip
+              open-delay="100"
+              bottom
+            >
+              <template #activator="{ on }">
+                <v-btn
+                  class="mr-1 hover-show-child"
+                  icon
                   small
+                  v-on="on"
+                  @click="clickEdit(type)"
                 >
-                  mdi-pencil
-                </v-icon>
-              </v-btn>
-            </template>
-            <span>Edit</span>
-          </v-tooltip>
+                  <v-icon
+                    small
+                  >
+                    mdi-pencil
+                  </v-icon>
+                </v-btn>
+              </template>
+              <span>Edit</span>
+            </v-tooltip>
+          </v-col>
         </v-row>
       </v-container>
     </div>
@@ -146,80 +149,69 @@ export default Vue.extend({
               </v-row>
             </v-container>
           </v-card-subtitle>
-          <v-container class="pt-0">
-            <v-row dense>
-              <v-col>
-                <v-text-field
-                  v-model="editingType"
-                  label="Name"
-                />
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-text-field
-                  v-model="editingThickness"
-                  type="number"
-                  :rules="[
-                    val => val >= 0 || 'Must be greater than 0'
-                  ]"
-                  required
-                  label="Line Thickness"
-                />
-              </v-col>
-              <v-col>
-                <v-checkbox
-                  v-model="editingFill"
-                  label="Fill"
-                  dense
-                  shrink
-                  hide-details
-                  class="my-1 ml-3 type-checkbox"
-                />
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-row class="my-0">
+          <v-card-text>
+            <v-form v-model="valid">
+              <v-row>
+                <v-col>
+                  <v-text-field
+                    v-model="editingType"
+                    label="Type Name"
+                    hide-details
+                  />
+                </v-col>
+              </v-row>
+              <v-row class="align-center">
+                <v-col>
+                  <v-text-field
+                    v-model="editingThickness"
+                    type="number"
+                    :rules="[
+                      val => val >= 0 || 'Must be >= 0'
+                    ]"
+                    required
+                    hide-details
+                    label="Box Border Thickness"
+                  />
+                </v-col>
+                <v-col>
+                  <v-checkbox
+                    v-model="editingFill"
+                    label="Fill"
+                    dense
+                    shrink
+                    hint="Toggle Box Shading"
+                    persistent-hint
+                  />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col>
                   <v-slider
                     v-model="editingOpacity"
+                    :label="`${parseFloat(editingOpacity).toFixed(2)}`"
                     min="0.0"
                     max="1.0"
                     step="0.01"
-                    class="align-center"
-                    height="10"
-                    dense
-                    label="Opacity"
-                    hide-details
-                  >
-                    <template v-slot:append>
-                      <v-text-field
-                        v-model="editingOpacity"
-                        class="mt-0 pt-0"
-                        :rules="[
-                          val => ( val >= 0 && val <= 1)|| 'Must be between 0 and 1'
-                        ]"
-                        single-line
-                        type="number"
-                        style="width: 60px"
-                      />
-                    </template>
-                  </v-slider>
-                </v-row>
-              </v-col>
-            </v-row>
-            <v-row
-              dense
-              align="center"
-            >
-              <v-col class="mx-2">
-                <v-color-picker
-                  v-model="editingColor"
-                  hide-inputs
-                />
-              </v-col>
-            </v-row>
-          </v-container>
+                    height="8"
+                    hint="Border & Fill Opacity"
+                    class="pr-3"
+                    persistent-hint
+                  />
+                </v-col>
+              </v-row>
+              <v-row
+                dense
+                align="center"
+              >
+                <v-col class="mx-2">
+                  <v-color-picker
+                    v-model="editingColor"
+                    hide-inputs
+                  />
+                </v-col>
+              </v-row>
+            </v-form>
+          </v-card-text>
           <v-card-actions>
             <v-spacer />
             <v-btn
@@ -232,6 +224,7 @@ export default Vue.extend({
             <v-btn
               color="primary"
               depressed
+              :disabled="!valid"
               @click="acceptChanges"
             >
               Save
@@ -244,13 +237,9 @@ export default Vue.extend({
 </template>
 
 <style scoped lang='scss'>
-.type-edit{
-  overflow: hidden;
-}
-
-.type-checkbox{
+.type-checkbox {
   max-width: 80%;
-  overflow:hidden;
+  overflow-wrap: anywhere;
 }
 
 .hover-show-parent {
@@ -264,5 +253,4 @@ export default Vue.extend({
     }
   }
 }
-
 </style>

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { PropType, Ref } from '@vue/composition-api';
 import Vue from 'vue';
+import { TypeStyling } from '../use/useStyling';
 
 export default Vue.extend({
   name: 'TypeList',
@@ -15,7 +16,7 @@ export default Vue.extend({
       required: true,
     },
     typeStyling: {
-      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
+      type: Object as PropType<Ref<TypeStyling>>,
       required: true,
     },
   },
@@ -24,8 +25,14 @@ export default Vue.extend({
       showPicker: false,
       selectedColor: '',
       selectedType: '',
+      selectedThickness: 5,
+      selectedFill: false,
+      selectedOpacity: 1.0,
       editingType: '',
       editingColor: '',
+      editingThickness: 5,
+      editingFill: false,
+      editingOpacity: 1.0,
     };
   },
   methods: {
@@ -35,15 +42,22 @@ export default Vue.extend({
       this.showPicker = true;
       this.selectedColor = this.typeStyling.value.color(type);
       this.editingColor = this.selectedColor;
+      this.selectedThickness = this.typeStyling.value.strokeWidth(type);
+      this.selectedFill = this.typeStyling.value.fill(type);
+      this.selectedOpacity = this.typeStyling.value.opacity(type);
     },
     acceptChanges() {
       this.showPicker = false;
       if (this.editingType !== this.selectedType) {
         this.$emit('update-type-name', { currentType: this.selectedType, newType: this.editingType });
       }
-      if (this.editingColor !== this.selectedColor) {
-        this.$emit('update-type-color', { type: this.editingType, color: this.editingColor });
-      }
+      this.$emit('update-type-style', {
+        type: this.editingType,
+        color: this.editingColor,
+        strokeWidth: this.editingThickness,
+        fill: this.editingFill,
+        opacity: this.editingOpacity,
+      });
       this.colorRefresh();
     },
     /**
@@ -142,6 +156,42 @@ export default Vue.extend({
                 <v-text-field
                   v-model="editingType"
                   label="Name"
+                />
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-text-field
+                  v-model="editingThickness"
+                  type="number"
+                  :rules="[
+                    val => (val || '').length > 0 || 'This field is required'
+                  ]"
+                  required
+                  label="Line Thickness"
+                  hide-details
+                />
+              </v-col>
+              <v-col>
+                <v-text-field
+                  v-model="editingOpacity"
+                  type="number"
+                  :rules="[
+                    val => (val >= 0 && val <= 1) || 'This field is required'
+                  ]"
+                  required
+                  label="Opacity"
+                  hide-details
+                />
+              </v-col>
+              <v-col>
+                <v-checkbox
+                  v-model="editingFill"
+                  label="Fill"
+                  dense
+                  shrink
+                  hide-details
+                  class="my-1 ml-3 type-checkbox"
                 />
               </v-col>
             </v-row>

--- a/client/src/components/layers/AnnotationLayer.ts
+++ b/client/src/components/layers/AnnotationLayer.ts
@@ -82,15 +82,40 @@ export default class AnnotationLayer extends BaseLayer<RectGeoJSData> {
         }
         return this.typeStyling.value.color('');
       },
+      fill: (data, _index) => {
+        if (data.confidencePairs) {
+          return this.typeStyling.value.fill(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.fill;
+      },
+      fillColor: (_point, _index, data) => {
+        if (data.confidencePairs) {
+          return this.typeStyling.value.color(data.confidencePairs[0]);
+        }
+        return this.typeStyling.value.color('');
+      },
+      fillOpacity: (_point, _index, data) => {
+        if (data.confidencePairs) {
+          return this.typeStyling.value.opacity(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.opacity;
+      },
       strokeOpacity: (_point, _index, data) => {
         if (data.selected) {
           return this.stateStyling.selected.opacity;
         }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.opacity(data.confidencePairs[0]);
+        }
+
         return this.stateStyling.standard.opacity;
       },
       strokeWidth: (_point, _index, data) => {
         if (data.selected) {
           return this.stateStyling.selected.strokeWidth;
+        }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
         }
         return this.stateStyling.standard.strokeWidth;
       },

--- a/client/src/components/layers/AnnotationLayer.ts
+++ b/client/src/components/layers/AnnotationLayer.ts
@@ -82,7 +82,7 @@ export default class AnnotationLayer extends BaseLayer<RectGeoJSData> {
         }
         return this.typeStyling.value.color('');
       },
-      fill: (data, _index) => {
+      fill: (data) => {
         if (data.confidencePairs) {
           return this.typeStyling.value.fill(data.confidencePairs[0]);
         }

--- a/client/src/components/layers/AnnotationLayer.ts
+++ b/client/src/components/layers/AnnotationLayer.ts
@@ -110,6 +110,15 @@ export default class AnnotationLayer extends BaseLayer<RectGeoJSData> {
 
         return this.stateStyling.standard.opacity;
       },
+      strokeOffset: (_point, _index, data) => {
+        if (data.selected) {
+          return this.stateStyling.selected.strokeWidth;
+        }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.strokeWidth;
+      },
       strokeWidth: (_point, _index, data) => {
         if (data.selected) {
           return this.stateStyling.selected.strokeWidth;

--- a/client/src/components/layers/BaseLayer.ts
+++ b/client/src/components/layers/BaseLayer.ts
@@ -11,6 +11,7 @@ export type ObjectFunction<T, D> = T | ((data: D, index: number) => T | undefine
 
 export interface LayerStyle<D> {
   strokeWidth?: StyleFunction<number, D>;
+  strokeOffset?: StyleFunction<number, D>;
   strokeOpacity?: StyleFunction<number, D>;
   strokeColor?: StyleFunction<string, D>;
   position?: (point: [number, number]) => { x: number; y: number };

--- a/client/src/components/layers/BaseLayer.ts
+++ b/client/src/components/layers/BaseLayer.ts
@@ -1,22 +1,24 @@
 /*eslint class-methods-use-this: "off"*/
 import { Annotator } from '@/components/annotators/annotatorType';
 import { FrameDataTrack } from '@/components/layers/LayerTypes';
-import { StateStyles } from '@/use/useStyling';
+import { StateStyles, TypeStyling } from '@/use/useStyling';
 import Vue from 'vue';
 import { Ref } from '@vue/composition-api';
 
 // eslint-disable-next-line max-len
 export type StyleFunction<T, D> = T | ((point: [number, number], index: number, data: D) => T | undefined);
+export type ObjectFunction<T, D> = T | ((data: D, index: number) => T | undefined);
 
 export interface LayerStyle<D> {
   strokeWidth?: StyleFunction<number, D>;
   strokeOpacity?: StyleFunction<number, D>;
   strokeColor?: StyleFunction<string, D>;
   position?: (point: [number, number]) => { x: number; y: number };
-  fillColor?: (data: D) => string;
+  fillColor?: StyleFunction<string, D>;
+  fillOpacity?: StyleFunction<number, D>;
   color?: (data: D) => string;
   offset?: (data: D) => { x: number; y: number };
-  fill?: boolean;
+  fill?: ObjectFunction<boolean, D> | boolean;
   radius?: number;
   [x: string]: unknown;
 }
@@ -25,7 +27,7 @@ export interface BaseLayerParams {
     frameData?: FrameDataTrack;
     annotator: Annotator;
     stateStyling: StateStyles;
-    typeStyling: Ref<{ color: (type: string) => string }>;
+    typeStyling: Ref<TypeStyling>;
 }
 
 export default abstract class BaseLayer<D> extends Vue {
@@ -37,7 +39,7 @@ export default abstract class BaseLayer<D> extends Vue {
 
     style: LayerStyle<D>;
 
-    typeStyling: Ref<{ color: (type: string) => string }>;
+    typeStyling: Ref<TypeStyling>;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     featureLayer: any;

--- a/client/src/components/layers/BaseLayer.ts
+++ b/client/src/components/layers/BaseLayer.ts
@@ -8,6 +8,7 @@ import { Ref } from '@vue/composition-api';
 // eslint-disable-next-line max-len
 export type StyleFunction<T, D> = T | ((point: [number, number], index: number, data: D) => T | undefined);
 export type ObjectFunction<T, D> = T | ((data: D, index: number) => T | undefined);
+export type PointFunction<T, D> = T | ((data: D) => T | undefined);
 
 export interface LayerStyle<D> {
   strokeWidth?: StyleFunction<number, D>;
@@ -15,7 +16,7 @@ export interface LayerStyle<D> {
   strokeOpacity?: StyleFunction<number, D>;
   strokeColor?: StyleFunction<string, D>;
   position?: (point: [number, number]) => { x: number; y: number };
-  fillColor?: StyleFunction<string, D>;
+  fillColor?: StyleFunction<string, D> | PointFunction<string, D>;
   fillOpacity?: StyleFunction<number, D>;
   color?: (data: D) => string;
   offset?: (data: D) => { x: number; y: number };

--- a/client/src/components/layers/MarkerLayer.ts
+++ b/client/src/components/layers/MarkerLayer.ts
@@ -44,7 +44,7 @@ export default class MarkerLayer extends BaseLayer<FormattedMarkerFeature> {
     return {
       ...baseStyle,
       fill: true,
-      fillColor: (data) => (data.feature === 'tail' ? 'orange' : 'blue'),
+      fillColor: (_point, _index, data) => (data.feature === 'tail' ? 'orange' : 'blue'),
       radius: 4,
     };
   }

--- a/client/src/components/layers/MarkerLayer.ts
+++ b/client/src/components/layers/MarkerLayer.ts
@@ -40,11 +40,10 @@ export default class MarkerLayer extends BaseLayer<FormattedMarkerFeature> {
   }
 
   createStyle(): LayerStyle<FormattedMarkerFeature> {
-    const baseStyle = super.createStyle();
     return {
-      ...baseStyle,
+      ...super.createStyle(),
       fill: true,
-      fillColor: (_point, _index, data) => (data.feature === 'tail' ? 'orange' : 'blue'),
+      fillColor: (data: FormattedMarkerFeature) => (data.feature === 'tail' ? 'orange' : 'blue'),
       radius: 4,
     };
   }

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -1,13 +1,14 @@
 
 import { computed, Ref } from '@vue/composition-api';
 import Track, { TrackId } from '@/lib/track';
+import { TypeStyling } from './useStyling';
 
 
 interface EventChartParams {
   enabledTrackIds: Readonly<Ref<readonly TrackId[]>>;
   selectedTrackId: Ref<TrackId | null>;
   trackMap: Map<TrackId, Track>;
-  typeStyling: Ref<{ color: (type: string) => string }>;
+  typeStyling: Ref<TypeStyling>;
 }
 
 interface EventChartData {

--- a/client/src/use/useGirderDataset.ts
+++ b/client/src/use/useGirderDataset.ts
@@ -5,6 +5,7 @@ import { ImageSequenceType, VideoType } from '@/constants';
 import { GirderModel } from '@girder/components/src';
 import { getClipMeta } from '@/lib/api/viameDetection.service';
 import { getItemsInFolder, getFolder, getItemDownloadUri } from '@/lib/api/girder.service';
+import { CustomStyle } from './useStyling';
 
 const defaultFrameRate = 30;
 
@@ -13,6 +14,7 @@ interface VIIMEDataset extends GirderModel {
     type: 'video' | 'image-sequence';
     fps: number;
     customTypeColors?: Record<string, string>;
+    customTypeStyling?: Record<string, CustomStyle>;
   };
 }
 

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -1,9 +1,10 @@
 import { computed, Ref } from '@vue/composition-api';
 import Track, { TrackId } from '@/lib/track';
+import { TypeStyling } from './useStyling';
 
 interface UseLineChartParams {
   enabledTrackIds: Readonly<Ref<readonly TrackId[]>>;
-  typeStyling: Ref<{ color: (type: string) => string }>;
+  typeStyling: Ref<TypeStyling>;
   trackMap: Map<TrackId, Track>;
   allTypes: Readonly<Ref<readonly string[]>>;
 }

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -71,40 +71,51 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     opacity: 0.45,
     fill: false,
   };
-  // Colors provided for the different Types
   const stateStyling: StateStyles = { standard, selected, disabled };
-  const typeColors = [];
 
-
-  const numColors = 12; //We can up the number of colors but they will become similar;
-  for (let i = 0; i < numColors; i += 1) {
+  /**
+   * Generates a color pallette to be used for mapping type names to colors.
+   * It generates colors from a rainbow spectrum and then takes a dark and lighter version
+   * of each color.
+   * @param {int} numColors - number of colors to attempt to generate the higher
+   * the number the more similar the colors will be.  Cyan like colors will be filtered out,
+   * so numColors isn't a guarantee of x*3 (normal, dark, light) colors.
+   */
+  function generateColors(numColors: number) {
+    const colorList = [];
+    for (let i = 0; i < numColors; i += 1) {
     //We are using a rainbow but we want to skip the cyan area so number will be reduced
-    const pos = (i * (1 / numColors));
-    if (pos > 0.58 && pos < 0.63) {
-      break;
+      const pos = (i * (1 / numColors));
+      if (pos > 0.58 && pos < 0.63) {
+        break;
+      }
+      const baseColor = d3.color(d3.interpolateRainbow(pos))?.hex();
+      if (baseColor) {
+        const hueColor = d3.hsl(baseColor);
+        hueColor.s = 1.0;
+        hueColor.l = 0.5;
+        colorList.push(hueColor.hex());
+        hueColor.s = 0.5;
+        hueColor.l = 0.35;
+        colorList.push(hueColor.hex());
+        hueColor.s = 1.0;
+        hueColor.l = 0.75;
+        colorList.push(hueColor.hex());
+      }
     }
-    const baseColor = d3.color(d3.interpolateRainbow(pos))?.hex();
-    if (baseColor) {
-      //typeColors.push(baseColor);
-      const hueColor = d3.hsl(baseColor);
-      hueColor.s = 1.0;
-      hueColor.l = 0.5;
-      typeColors.push(hueColor.hex());
-      hueColor.s = 0.5;
-      hueColor.l = 0.35;
-      typeColors.push(hueColor.hex());
-      hueColor.s = 1.0;
-      hueColor.l = 0.75;
-      typeColors.push(hueColor.hex());
-    }
+
+    //Mix up colors in a uniform way so reloads have the same types associated with the same colors
+    let seed = 0.5;
+    colorList.sort(() => {
+      seed += seed;
+      return Math.cos(seed);
+    });
+    return colorList;
   }
 
-  //Mix up colors in a uniform way for each launch
-  let seed = 0.5;
-  typeColors.sort(() => {
-    seed += seed;
-    return Math.cos(seed);
-  });
+  //Generate Colors for the types.
+  const typeColors = generateColors(12);
+
 
   function loadTypeStyles({ styles, colorList }:
     { styles?: Record<string, CustomStyle>; colorList?: Record<string, string> }) {

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -77,10 +77,20 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     colors.green.darken3,
   ];
 
-  function loadTypeStyles(list?: Record<string, CustomStyle>) {
-    if (list) {
+  function loadTypeStyles({ styles, colorList }:
+    { styles?: Record<string, CustomStyle>; colorList?: Record<string, string> }) {
+    //Handles old style Colors first
+    if (colorList) {
+      Object.entries(colorList).forEach(([key, value]) => {
+        if (!customStyles.value[key]) {
+          customStyles.value[key] = {};
+        }
+        Vue.set(customStyles.value[key], 'color', value);
+      });
+    }
+    if (styles) {
       // Copy over the item so they can be modified in future
-      Object.entries(list).forEach(([key, value]) => {
+      Object.entries(styles).forEach(([key, value]) => {
         Vue.set(customStyles.value, key, value);
       });
     }
@@ -91,7 +101,6 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     type, color, strokeWidth, opacity, fill,
   }:
     {type: string; color?: string; strokeWidth?: number; opacity?: number; fill?: boolean}) {
-    console.log(`Update Type: ${type} color:${color} width:${strokeWidth}`);
     if (!customStyles.value[type]) {
       Vue.set(customStyles.value, type, {});
     }
@@ -99,7 +108,6 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
       color, strokeWidth, opacity, fill,
     };
     Object.entries(args).forEach(([key, value]) => {
-      console.log(`key: ${key} value:${value}`);
       if (value !== undefined) {
         if (!customStyles.value[type]) {
           Vue.set(customStyles.value, type, {});
@@ -107,7 +115,6 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
         Vue.set(customStyles.value[type], key, value);
       }
     });
-    console.log(customStyles);
     markChangesPending();
   }
 
@@ -131,7 +138,7 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
         return stateStyling.standard.strokeWidth;
       },
       fill: (type: string) => {
-        if (_customStyles[type] && _customStyles[type].fill) {
+        if (_customStyles[type] && _customStyles[type].fill !== undefined) {
           return _customStyles[type].fill;
         }
         return stateStyling.standard.fill;

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -32,6 +32,13 @@ export interface TypeStyling {
   opacity: (type: string) => number;
 }
 
+interface UpdateStylingArgs {
+  type: string;
+  color?: string;
+  strokeWidth?: number;
+  opacity?: number;
+  fill?: boolean;
+}
 interface UseStylingParams {
   markChangesPending: () => void;
 }
@@ -102,7 +109,6 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
   function loadTypeStyles({ styles, colorList }:
     { styles?: Record<string, CustomStyle>; colorList?: Record<string, string> }) {
     //Handles old style Colors first
-
     if (colorList) {
       Object.entries(colorList).forEach(([key, value]) => {
         if (!customStyles.value[key]) {
@@ -119,17 +125,11 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     }
   }
 
-
-  function updateTypeStyle({
-    type, color, strokeWidth, opacity, fill,
-  }:
-    {type: string; color?: string; strokeWidth?: number; opacity?: number; fill?: boolean}) {
+  function updateTypeStyle(args: UpdateStylingArgs) {
+    const { type } = args;
     if (!customStyles.value[type]) {
       Vue.set(customStyles.value, type, {});
     }
-    const args = {
-      color, strokeWidth, opacity, fill,
-    };
     Object.entries(args).forEach(([key, value]) => {
       if (value !== undefined) {
         if (!customStyles.value[type]) {

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import {
   inject, ref, Ref, computed,
 } from '@vue/composition-api';
-import colors from 'vuetify/lib/util/colors';
 import * as d3 from 'd3';
 import { Vuetify } from 'vuetify';
 import { setMetadataForFolder } from '@/lib/api/viame.service';
@@ -67,20 +66,17 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
   };
   // Colors provided for the different Types
   const stateStyling: StateStyles = { standard, selected, disabled };
-  const typeColors = [
-    // colors.red.accent1,
-    // colors.yellow.darken3,
-    // colors.purple.lighten3,
-    // colors.green.lighten3,
-    // colors.yellow.lighten3,
-    // colors.purple.darken3,
-    // colors.green.darken3,
-  ];
+  const typeColors = [];
 
 
-  const numColors = 8;
+  const numColors = 12; //We can up the number of colors but they will become similar;
   for (let i = 0; i < numColors; i += 1) {
-    const baseColor = d3.color(d3.interpolateSpectral(i * (1 / numColors)))?.hex();
+    //We are using a rainbow but we want to skip the cyan area so number will be reduced
+    const pos = (i * (1 / numColors));
+    if (pos > 0.58 && pos < 0.63) {
+      break;
+    }
+    const baseColor = d3.color(d3.interpolateRainbow(pos))?.hex();
     if (baseColor) {
       //typeColors.push(baseColor);
       const hueColor = d3.hsl(baseColor);
@@ -88,26 +84,29 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
       hueColor.l = 0.5;
       typeColors.push(hueColor.hex());
       hueColor.s = 0.5;
-      hueColor.l = 0.25;
+      hueColor.l = 0.35;
       typeColors.push(hueColor.hex());
-      hueColor.s = 0.5;
+      hueColor.s = 1.0;
       hueColor.l = 0.75;
       typeColors.push(hueColor.hex());
     }
   }
-  let seed = 0;
-  typeColors.sort((a, b) => {
-    seed += Math.PI;
+
+  //Mix up colors in a uniform way for each launch
+  let seed = 0.5;
+  typeColors.sort(() => {
+    seed += seed;
     return Math.cos(seed);
   });
 
   function loadTypeStyles({ styles, colorList }:
     { styles?: Record<string, CustomStyle>; colorList?: Record<string, string> }) {
     //Handles old style Colors first
+
     if (colorList) {
       Object.entries(colorList).forEach(([key, value]) => {
         if (!customStyles.value[key]) {
-          customStyles.value[key] = {};
+          Vue.set(customStyles.value, key, {});
         }
         Vue.set(customStyles.value[key], 'color', value);
       });

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -77,6 +77,26 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     colors.green.darken3,
   ];
 
+  /*
+  const numColors = 8;
+  for (let i = 0; i < numColors; i += 1) {
+    const baseColor = d3.color(d3.interpolateSpectral(i * (1 / numColors)))?.hex();
+    if (baseColor) {
+      //typeColors.push(baseColor);
+      const hueColor = d3.hsl(baseColor);
+      hueColor.s = 1.0;
+      hueColor.l = 0.5;
+      typeColors.push(hueColor.hex());
+      hueColor.s = 0.5;
+      hueColor.l = 0.25;
+      typeColors.push(hueColor.hex());
+      hueColor.s = 0.5;
+      hueColor.l = 0.75;
+      typeColors.push(hueColor.hex());
+    }
+  }
+  */
+
   function loadTypeStyles({ styles, colorList }:
     { styles?: Record<string, CustomStyle>; colorList?: Record<string, string> }) {
     //Handles old style Colors first

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -43,6 +43,45 @@ interface UseStylingParams {
   markChangesPending: () => void;
 }
 
+/**
+   * Generates a color pallette as a list of hex colors.
+   * It generates colors from a rainbow spectrum and then takes a dark and lighter version
+   * of each color.
+   * @param {int} numColors - number of colors to attempt to generate the higher
+   * the number the more similar the colors will be.  Cyan like colors will be filtered out,
+   * so numColors isn't a guarantee of x*3 (normal, dark, light) colors.
+   */
+function generateColors(numColors: number) {
+  const colorList = [];
+  for (let i = 0; i < numColors; i += 1) {
+    //We are using a rainbow but we want to skip the cyan area so number will be reduced
+    const pos = (i * (1 / numColors));
+    if (pos > 0.58 && pos < 0.63) {
+      break;
+    }
+    const baseColor = d3.color(d3.interpolateRainbow(pos))?.hex();
+    if (baseColor) {
+      const hueColor = d3.hsl(baseColor);
+      hueColor.s = 1.0;
+      hueColor.l = 0.5;
+      colorList.push(hueColor.hex());
+      hueColor.s = 0.5;
+      hueColor.l = 0.35;
+      colorList.push(hueColor.hex());
+      hueColor.s = 1.0;
+      hueColor.l = 0.75;
+      colorList.push(hueColor.hex());
+    }
+  }
+
+  //Mix up colors in a uniform way so reloads have the same types associated with the same colors
+  let seed = 0.5;
+  colorList.sort(() => {
+    seed += seed;
+    return Math.cos(seed);
+  });
+  return colorList;
+}
 
 export default function useStyling({ markChangesPending }: UseStylingParams) {
   const vuetify = inject('vuetify') as Vuetify;
@@ -72,47 +111,6 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     fill: false,
   };
   const stateStyling: StateStyles = { standard, selected, disabled };
-
-  /**
-   * Generates a color pallette to be used for mapping type names to colors.
-   * It generates colors from a rainbow spectrum and then takes a dark and lighter version
-   * of each color.
-   * @param {int} numColors - number of colors to attempt to generate the higher
-   * the number the more similar the colors will be.  Cyan like colors will be filtered out,
-   * so numColors isn't a guarantee of x*3 (normal, dark, light) colors.
-   */
-  function generateColors(numColors: number) {
-    const colorList = [];
-    for (let i = 0; i < numColors; i += 1) {
-    //We are using a rainbow but we want to skip the cyan area so number will be reduced
-      const pos = (i * (1 / numColors));
-      if (pos > 0.58 && pos < 0.63) {
-        break;
-      }
-      const baseColor = d3.color(d3.interpolateRainbow(pos))?.hex();
-      if (baseColor) {
-        const hueColor = d3.hsl(baseColor);
-        hueColor.s = 1.0;
-        hueColor.l = 0.5;
-        colorList.push(hueColor.hex());
-        hueColor.s = 0.5;
-        hueColor.l = 0.35;
-        colorList.push(hueColor.hex());
-        hueColor.s = 1.0;
-        hueColor.l = 0.75;
-        colorList.push(hueColor.hex());
-      }
-    }
-
-    //Mix up colors in a uniform way so reloads have the same types associated with the same colors
-    let seed = 0.5;
-    colorList.sort(() => {
-      seed += seed;
-      return Math.cos(seed);
-    });
-    return colorList;
-  }
-
   //Generate Colors for the types.
   const typeColors = generateColors(12);
 

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -120,6 +120,9 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     if (styles) {
       // Copy over the item so they can be modified in future
       Object.entries(styles).forEach(([key, value]) => {
+        if (!customStyles.value[key]) {
+          Vue.set(customStyles.value, key, {});
+        }
         Vue.set(customStyles.value, key, value);
       });
     }

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -68,16 +68,16 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
   // Colors provided for the different Types
   const stateStyling: StateStyles = { standard, selected, disabled };
   const typeColors = [
-    colors.red.accent1,
-    colors.yellow.darken3,
-    colors.purple.lighten3,
-    colors.green.lighten3,
-    colors.yellow.lighten3,
-    colors.purple.darken3,
-    colors.green.darken3,
+    // colors.red.accent1,
+    // colors.yellow.darken3,
+    // colors.purple.lighten3,
+    // colors.green.lighten3,
+    // colors.yellow.lighten3,
+    // colors.purple.darken3,
+    // colors.green.darken3,
   ];
 
-  /*
+
   const numColors = 8;
   for (let i = 0; i < numColors; i += 1) {
     const baseColor = d3.color(d3.interpolateSpectral(i * (1 / numColors)))?.hex();
@@ -95,7 +95,11 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
       typeColors.push(hueColor.hex());
     }
   }
-  */
+  let seed = 0;
+  typeColors.sort((a, b) => {
+    seed += Math.PI;
+    return Math.cos(seed);
+  });
 
   function loadTypeStyles({ styles, colorList }:
     { styles?: Record<string, CustomStyle>; colorList?: Record<string, string> }) {

--- a/client/src/views/TrackViewer/Layers.vue
+++ b/client/src/views/TrackViewer/Layers.vue
@@ -19,7 +19,7 @@ import EditAnnotationLayer from '@/components/layers/EditAnnotationLayer';
 import MarkerLayer from '@/components/layers/MarkerLayer';
 import { geojsonToBound } from '@/utils';
 import { FeaturePointingTarget } from '@/use/useFeaturePointing';
-import { StateStyles } from '@/use/useStyling';
+import { StateStyles, TypeStyling } from '@/use/useStyling';
 
 export default defineComponent({
   props: {
@@ -44,7 +44,7 @@ export default defineComponent({
       required: true,
     },
     typeStyling: {
-      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
+      type: Object as PropType<Ref<TypeStyling>>,
       required: true,
     },
     stateStyling: {

--- a/client/src/views/TrackViewer/Sidebar.vue
+++ b/client/src/views/TrackViewer/Sidebar.vue
@@ -12,6 +12,7 @@ import TypeList from '@/components/TypeList.vue';
 import TrackList from '@/components/TrackList.vue';
 import Track, { TrackId } from '@/lib/track';
 import { NewTrackSettings } from '@/use/useSettings';
+import { TypeStyling } from '../../use/useStyling';
 
 export default defineComponent({
   props: {
@@ -48,7 +49,7 @@ export default defineComponent({
       required: true,
     },
     typeStyling: {
-      type: Object as PropType<Ref<{ color: (t: string) => string }>>,
+      type: Object as PropType<Ref<TypeStyling>>,
       required: true,
     },
     width: {
@@ -122,8 +123,8 @@ export default defineComponent({
         <type-list
           v-bind="trackListProps"
           class="flex-shrink-1 flex-grow-1 typelist"
-          @update-type-color="$emit('update-type-color',$event)"
           @update-type-name="$emit('update-type-name',$event)"
+          @update-type-style="$emit('update-type-style',$event)"
         />
         <slot />
         <v-spacer />

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -120,7 +120,10 @@ export default defineComponent({
       throw err;
     }).then(() => {
       // tasks to run after dataset and tracks have loaded
-      loadTypeStyles(dataset.value?.meta.customTypeStyling);
+      loadTypeStyles({
+        styles: dataset.value?.meta.customTypeStyling,
+        colorList: dataset.value?.meta.customTypeColors,
+      });
     });
 
     const {

--- a/client/src/views/TrackViewer/Viewer.vue
+++ b/client/src/views/TrackViewer/Viewer.vue
@@ -74,9 +74,9 @@ export default defineComponent({
     const {
       typeStyling,
       stateStyling,
-      updateTypeColor,
-      loadTypeColors,
-      saveTypeColors,
+      updateTypeStyle,
+      loadTypeStyles,
+      saveTypeStyles,
     } = useStyling({ markChangesPending });
 
     const {
@@ -120,7 +120,7 @@ export default defineComponent({
       throw err;
     }).then(() => {
       // tasks to run after dataset and tracks have loaded
-      loadTypeColors(dataset.value?.meta.customTypeColors);
+      loadTypeStyles(dataset.value?.meta.customTypeStyling);
     });
 
     const {
@@ -203,7 +203,7 @@ export default defineComponent({
         selectTrack(selectedTrackId.value, false);
       }
       saveToServer(datasetId, trackMap);
-      saveTypeColors(datasetId, allTypes);
+      saveTypeStyles(datasetId, allTypes);
     }
 
 
@@ -229,7 +229,7 @@ export default defineComponent({
       splitTracks,
       toggleFeaturePointing,
       featurePointed,
-      updateTypeColor,
+      updateTypeStyle,
       updateTypeName,
       /* props for sub-components */
       controlsContainerProps: {
@@ -329,7 +329,7 @@ export default defineComponent({
         @track-type-change="handler.trackTypeChange($event)"
         @update-new-track-settings="updateNewTrackSettings($event)"
         @track-split="splitTracks($event, frame)"
-        @update-type-color="updateTypeColor($event)"
+        @update-type-style="updateTypeStyle($event)"
         @update-type-name="updateTypeName($event)"
       >
         <ConfidenceFilter :confidence.sync="confidenceThreshold" />


### PR DESCRIPTION
Allows a user to edit the type styling

- The user can now set per Type: Color, name, opacity, filled, line thickness.
- I've updated the usage of the type styling to be one interface that can be updated in the future with other elements if needed.
- AnnotationLayers have additional styling options added to reflect updates
- Each style item has a function like the color styling before.  If a value doesn't exist it will default back to the standard styling just like before.
- It will load the old style customColors as well as a new style CustomStyles.  I wanted to maintain support in case anyone was using the old way.
- Also added in a method of generating colors right now which utilizes d3's rainbow and then messes with Hue (HSL) values to get a darker and lighter version of each color.  It creates ~ 2 something colors.  I intentionally avoid Cyan like colors.

![image](https://user-images.githubusercontent.com/61746913/86379018-4a6ca700-bc58-11ea-8868-668c6d2352e8.png)

Fixes #181 
Fixes #101 