### PR TITLE
Feature/interpolation eventchart

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -184,7 +184,7 @@ export default {
       >
     </v-row>
     <v-row
-      class="px-3 py-1 justify-center item-row"
+      class="px-3 py-1 justify-center item-row flex-nowrap"
     >
       <template v-if="selected">
         <v-btn

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -148,9 +148,12 @@ export default {
       }
       canvas.width = this.clientWidth;
       canvas.height = bars.slice(-1)[0].top + 15;
+      let selectedBar = null;
       bars.forEach((bar) => {
         const typeColor = bar.color ? bar.color : '#4c9ac2';
         if (bar.selected) {
+          selectedBar = bar;
+          /*
           ctx.fillStyle = 'white';
           bar.markers
             .map((n) => this.x(n))
@@ -172,6 +175,7 @@ export default {
           );
           ctx.stroke();
           ctx.restore();
+          */
         } else {
           ctx.fillStyle = typeColor;
           ctx.fillRect(
@@ -182,6 +186,42 @@ export default {
           );
         }
       });
+      if (selectedBar) {
+        //draw screen
+        ctx.fillStyle = '#000000DD'; //black with opacity
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        const bar = selectedBar;
+        const typeColor = bar.color ? bar.color : '#4c9ac2';
+        ctx.fillStyle = typeColor;
+        ctx.strokeStyle = typeColor;
+        ctx.lineWidth = 2;
+        ctx.fillRect(
+          bar.left,
+          bar.top,
+          bar.width,
+          10,
+        );
+        ctx.fillStyle = '#000000AA'; //black with opacity
+        ctx.fillRect(
+          bar.left,
+          bar.top,
+          bar.width,
+          10,
+        );
+        ctx.fillStyle = typeColor;
+        bar.markers
+          .map((n) => this.x(n))
+          .slice(0, bar.markers.length - 1)
+          .forEach((m, i) => {
+            const current = bar.markers[i];
+            const next = bar.markers[i + 1];
+            const width = (current + 1 === next) ? 2 : 5;
+            ctx.fillRect(m, bar.top, width, 10);
+          });
+        // ctx.save();
+
+        //ctx.restore();
+      }
     },
     mousemove(e) {
       this.tooltip = null;

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -149,6 +149,7 @@ export default {
       }
       canvas.width = this.clientWidth;
       canvas.height = bars.slice(-1)[0].top + 15;
+      const overflow = 1.1; // CHANGE to > ~1.05 if you want overlapping or not keyframes
       let selectedBar = null;
       bars.forEach((bar) => {
         const typeColor = bar.color ? bar.color : '#4c9ac2';
@@ -156,9 +157,10 @@ export default {
           //Save the selectedBar for drawing after all other are complete
           selectedBar = bar;
         } else {
+          const width = (bar.width / (bar.length - 1)) * overflow;
           ctx.fillStyle = typeColor;
           ctx.fillRect(
-            bar.left,
+            bar.left - width / 2.0,
             bar.top,
             bar.width,
             10,
@@ -171,11 +173,12 @@ export default {
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         const bar = selectedBar;
         const typeColor = bar.color ? bar.color : '#4c9ac2';
+        const width = (bar.width / (bar.length - 1)) * overflow;
         ctx.fillStyle = typeColor;
         ctx.lineWidth = 2;
         //Draw the background rect color
         ctx.fillRect(
-          bar.left,
+          bar.left - width / 2.0,
           bar.top,
           bar.width,
           10,
@@ -192,8 +195,6 @@ export default {
           );
           //Draw the markers for the keyframes
           ctx.fillStyle = typeColor;
-          const overflow = 1.10; // CHANGE to > ~1.05 if you want overlapping or not keyframes
-          const width = (bar.width / (bar.length - 1)) * overflow;
           let widthDivisor = 1;
           bar.markers
             .map((n) => this.x(n))

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -157,10 +157,9 @@ export default {
           //Save the selectedBar for drawing after all other are complete
           selectedBar = bar;
         } else {
-          const width = (bar.width / (bar.length - 1)) * overflow;
           ctx.fillStyle = typeColor;
           ctx.fillRect(
-            bar.left - width / 2.0,
+            bar.left,
             bar.top,
             bar.width,
             10,
@@ -184,7 +183,7 @@ export default {
           10,
         );
         //Only complicate drawing if there are less markers than total frames in a bar
-        if (bar.length !== bar.markers.length) {
+        if (bar.length !== bar.markers.length - 1) {
         //Draw a screen over the color to mute it
           ctx.fillStyle = '#00000088'; //black with opacity
           ctx.fillRect(

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -153,30 +153,8 @@ export default {
       bars.forEach((bar) => {
         const typeColor = bar.color ? bar.color : '#4c9ac2';
         if (bar.selected) {
+          //Save the selectedBar for drawing after all other are complete
           selectedBar = bar;
-          /*
-          ctx.fillStyle = 'white';
-          bar.markers
-            .map((n) => this.x(n))
-            .slice(0, bar.markers.length - 1)
-            .forEach((m, i) => {
-              const current = bar.markers[i];
-              const next = bar.markers[i + 1];
-              const width = (current + 1 === next) ? 2 : 5;
-              ctx.fillRect(m, bar.top, width, 10);
-            });
-          ctx.save();
-          ctx.strokeStyle = 'white';
-          ctx.lineWidth = 2;
-          ctx.rect(
-            bar.left,
-            bar.top,
-            bar.width,
-            10,
-          );
-          ctx.stroke();
-          ctx.restore();
-          */
         } else {
           ctx.fillStyle = typeColor;
           ctx.fillRect(
@@ -194,40 +172,39 @@ export default {
         const bar = selectedBar;
         const typeColor = bar.color ? bar.color : '#4c9ac2';
         ctx.fillStyle = typeColor;
-        ctx.strokeStyle = typeColor;
         ctx.lineWidth = 2;
+        //Draw the background rect color
         ctx.fillRect(
           bar.left,
           bar.top,
           bar.width,
           10,
         );
-        ctx.fillStyle = '#00000088'; //black with opacity
-        ctx.fillRect(
-          bar.left,
-          bar.top,
-          bar.width,
-          10,
-        );
-        ctx.fillStyle = typeColor;
-        const width = bar.width / (bar.length - 1);
-        let widthDivisor = 1;
-        bar.markers
-          .map((n) => this.x(n))
-          .slice(0, bar.markers.length)
-          .forEach((m, i) => {
-            const current = bar.markers[i];
-            const next = bar.markers[i + 1];
-            if (i === bar.markers.length - 1) {
-              widthDivisor = 2.0;
-            }
-            ctx.fillRect(m - width / 2.0, bar.top, width / widthDivisor, 10);
-            // ctx.fillStyle = '#AAAAAA77';
-            // ctx.fillRect(m - width / 2.0, bar.top, width, 10);
-          });
-        // ctx.save();
-
-        //ctx.restore();
+        //Only complicate drawing if there are less markers than total frames in a bar
+        if (bar.length !== bar.markers.length) {
+        //Draw a screen over the color to mute it
+          ctx.fillStyle = '#00000088'; //black with opacity
+          ctx.fillRect(
+            bar.left,
+            bar.top,
+            bar.width,
+            10,
+          );
+          //Draw the markers for the keyframes
+          ctx.fillStyle = typeColor;
+          const overflow = 1.10; // CHANGE to > ~1.05 if you want overlapping or not keyframes
+          const width = (bar.width / (bar.length - 1)) * overflow;
+          let widthDivisor = 1;
+          bar.markers
+            .map((n) => this.x(n))
+            .slice(0, bar.markers.length)
+            .forEach((m, i) => {
+              if (i === bar.markers.length - 1) {
+                widthDivisor = 2.0;
+              }
+              ctx.fillRect(m - width / 2.0, bar.top, width / widthDivisor, 10);
+            });
+        }
       }
     },
     mousemove(e) {

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -95,6 +95,7 @@ export default {
                 color: event.color,
                 selected: event.selected,
                 name: event.name,
+                length: event.range[1] - event.range[0],
                 markers: event.markers,
               });
             });
@@ -201,7 +202,7 @@ export default {
           bar.width,
           10,
         );
-        ctx.fillStyle = '#000000AA'; //black with opacity
+        ctx.fillStyle = '#00000088'; //black with opacity
         ctx.fillRect(
           bar.left,
           bar.top,
@@ -209,14 +210,20 @@ export default {
           10,
         );
         ctx.fillStyle = typeColor;
+        const width = bar.width / (bar.length - 1);
+        let widthDivisor = 1;
         bar.markers
           .map((n) => this.x(n))
-          .slice(0, bar.markers.length - 1)
+          .slice(0, bar.markers.length)
           .forEach((m, i) => {
             const current = bar.markers[i];
             const next = bar.markers[i + 1];
-            const width = (current + 1 === next) ? 2 : 5;
-            ctx.fillRect(m, bar.top, width, 10);
+            if (i === bar.markers.length - 1) {
+              widthDivisor = 2.0;
+            }
+            ctx.fillRect(m - width / 2.0, bar.top, width / widthDivisor, 10);
+            // ctx.fillStyle = '#AAAAAA77';
+            // ctx.fillRect(m - width / 2.0, bar.top, width, 10);
           });
         // ctx.save();
 

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -276,6 +276,7 @@ export default {
       width: 0;
       height: 100%;
       border-left: 1px solid #299be3;
+      z-index:1;
     }
 
     .child {

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -25,6 +25,7 @@ export default function useEventChart({
   const eventChartData = computed(() => {
     const values = [] as EventChartData[];
     const mapfunc = typeStyling.value.color;
+    const selectedTrackIdValue = selectedTrackId.value;
     /* use forEach rather than filter().map() to save an interation */
     enabledTrackIds.value.forEach((trackId) => {
       const track = trackMap.get(trackId);
@@ -38,13 +39,16 @@ export default function useEventChart({
           trackId,
           name: `Track ${trackId}`,
           color: mapfunc(trackType),
-          selected: trackId === selectedTrackId.value,
+          selected: trackId === selectedTrackIdValue,
           range: [track.begin, track.end],
           markers: track.featureIndex,
         });
       }
     });
-    return values;
+    return {
+      muted: selectedTrackIdValue !== null,
+      values,
+    };
   });
 
   return { eventChartData };


### PR DESCRIPTION
Feel free to reject if you want or to pilfer some of the code if needed.

Adjusts the keyframes so they are relational to the size of the width of the entire bar.  A keyframe should be dependent on the timeline width now.

This changes an annoying thing I've noticed in the timeline where all events occur on the leading edge of the keyframe.  This ceners an event so if you are on a frame, the keyframe goes to the left and the right of the current spot.

Also added a screen to the event viewer when an object is selected. 

If you don't like the idea of consecutive keyframes being represented as a a block just change the overflow variable and remove the check to see if the `bars.length === bar.markers.length`.  The one thing this doesn't handle properly are the empty spots in a track where there aren't any detections.

![image](https://user-images.githubusercontent.com/61746913/86354713-85aaae00-bc37-11ea-8cc0-63f6c9a1605f.png)
