### PR TITLE
Move docker docs to another README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Additional documentation will be available in the future for users.
 
 ## Documentation
 
-* [User Guide](https://github.com/VIAME/VIAME-Web/wiki/User-Documentation)
+* [Client User Guide](https://github.com/VIAME/VIAME-Web/wiki/User-Documentation)
 * [Client Development Docs](client/README.md)
+* [Docker Getting Started Guide](docker/README.md)
 
 ## Code Architecture
 
@@ -40,42 +41,11 @@ Run `pip install` on the against the server directory. Then `girder build` , `gi
 The processing server is a typical Girder worker tasks. Generally, it needs a running RabbitMQ instance. Python3, and a python environment.
 Run `pip install` on the against the server directory. Then `girder-worker -l info` to start girder worker.
 
-## Running Locally
-
-You can run VIAME Web locally with vanilla docker-compose. Configure options in `.env`.
-
-> **Note:** Pipeline runner requires [Nividia-Docker2 (deprecated)](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) because GPU support for docker-compose has [not yet landed](https://github.com/docker/compose/issues/6691)
-
-### Use pre-built images
-
-``` bash
-# Pull pre-built images
-docker-compose -f docker/docker-compose.yml pull
-# Bring the stack up
-docker-compose -f docker/docker-compose.yml up
-```
-
-VIAME server will be running at http://localhost:8010/
-
-You can run the data viewer without needing GPU support as well
-
-``` bash
-docker-compose -f docker/docker-compose.yml up girder
-```
-
-### Build your own images
-
-> **Note:** In order to build images yourself, the `.git` folder must exist, so you must `git clone` from source control.  A release archive zip can be used too, but only to run pre-built images from a container registry.
-
-``` bash
-docker-compose -f docker/docker-compose.yml build
-```
-
 ## Example Data
 
 ### Input
 
-VIAME-Web takes two different kinds of input data, either a video file (e.g..mpg) or an image sequence. Both types can
+VIAME-Web takes two different kinds of input data, either a video file (e.g. .mpg) or an image sequence. Both types can
 be optionally accompanied with a CSV file containing video annotations. Example input sequences are available at
 https://viame.kitware.com/girder#collections.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,66 @@
+# Docker Documentation
+
+VIAME-Web is easiest to set up with docker.
+
+## docker-compose
+
+We recommend running VIAME Web with docker-compose. Clone this repository and configure options in `.env`.
+
+> **Note:** Pipeline runner requires [Nividia-Docker2 (deprecated)](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) because GPU support for docker-compose has [not yet landed](https://github.com/docker/compose/issues/6691)
+
+``` bash
+# Pull pre-built images
+docker-compose -f docker/docker-compose.yml pull
+# Bring the services up
+docker-compose -f docker/docker-compose.yml up
+```
+
+VIAME server will be running at http://localhost:8010/
+
+You can run the data viewer without needing GPU support as well
+
+``` bash
+docker-compose -f docker/docker-compose.yml up girder
+```
+
+## Images
+
+VIAME-web consists of 2 main services.
+
+* [Girder (Web Server)](https://hub.docker.com/r/kitware/viame-web)
+* [Worker (GPU Pipeline Runner)](https://hub.docker.com/r/kitware/viame-worker)
+
+In addition, a database (Mongodb) and a queue processor (RabbitMQ) are required.
+
+### Girder Web Server
+
+This image contains both the backend and client.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| VIAME_PIPELINES_PATH | none | A path inside the **other** worker container where VIAME pipelines can be found.  You must mount this path. |
+| GIRDER_MONGO_URI | mongodb://mongo:27017/girder | a mongodb connection string |
+| GIRDER_ADMIN_USER | admin | admin username |
+| GIRDER_ADMIN_PASS | viame | admin password |
+| CELERY_BROKER_URL | amqp://guest:guest@rabbit/ | rabbitmq connection string |
+| BROKER_CONNECTION_TIMEOUT | 2 | rabbitmq connection timeout |
+
+[Read more about configuring girder.](https://girder.readthedocs.io/en/latest/)
+
+### Girder Worker
+
+This image contains a celery worker to run VIAME pipelines and transcoding jobs.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| VIAME_PIPELINES_PATH | none | A path inside the container where VIAME pipelines can be found.  |
+| CELERY_BROKER_URL | amqp://guest:guest@rabbit/ | rabbitmq connection string |
+| BROKER_CONNECTION_TIMEOUT | 2 | rabbitmq connection timeout |
+
+## Build your own images
+
+> **Note:** In order to build images yourself, the `.git` folder must exist, so you must `git clone` from source control.  A release archive zip can be used too, but only to run pre-built images from a container registry.
+
+``` bash
+docker-compose -f docker/docker-compose.yml build
+```

--- a/docker/girder.Dockerfile
+++ b/docker/girder.Dockerfile
@@ -1,5 +1,6 @@
 FROM node:latest as builder
 WORKDIR /app
+
 # Install dependencies
 COPY client/package.json client/yarn.lock /app/
 RUN yarn --frozen-lockfile
@@ -10,6 +11,12 @@ RUN yarn build
 
 
 FROM girder/girder as runtime
+
+ENV GIRDER_MONGO_URI mongodb://mongo:27017/girder
+ENV GIRDER_ADMIN_USER admin
+ENV GIRDER_ADMIN_PASSWORD viame
+ENV CELERY_BROKER_URL amqp://guest:guest@rabbit/
+ENV BROKER_CONNECTION_TIMEOUT 2
 
 COPY --from=builder /app/dist/ /usr/share/girder/static/viame/
 

--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -2,6 +2,9 @@ FROM kitware/viame:gpu-all-models-latest
 # expects VIAME install at /opt/noaa/viame/
 # expects VIAME pipelines at /opt/noaa/viame/configs/pipelines/
 
+ENV CELERY_BROKER_URL amqp://guest:guest@rabbit/
+ENV BROKER_CONNECTION_TIMEOUT 2
+
 WORKDIR /home/viame_girder
 
 # BEGIN: Porting girder worker install from girder/girder_worker Dockerfile.py3


### PR DESCRIPTION
New README: https://github.com/VIAME/VIAME-Web/blob/fd6ac189499df3dde555a81badbf246003e4ae1e/README.md
New Docker README: https://github.com/VIAME/VIAME-Web/blob/fd6ac189499df3dde555a81badbf246003e4ae1e/docker/README.md