### PR TITLE
clean up eventChart code

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -184,7 +184,7 @@ export default {
       >
     </v-row>
     <v-row
-      class="px-3 py-1 justify-center item-row"
+      class="px-3 py-1 justify-center item-row flex-nowrap"
     >
       <template v-if="selected">
         <v-btn

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -151,7 +151,6 @@ export default {
       const overflow = 0.6; // How much of a frame-width each detection box should occupy
       const barHeight = 10;
       bars.forEach((bar) => {
-        const featureWidth = (bar.width / (bar.length - 1)) * overflow;
         if (!bar.selected) {
           // If this bar is not selected
           const typeColor = bar.color ? bar.color : '#4c9ac2';
@@ -168,12 +167,8 @@ export default {
           // Else draw individual feature frame segments
           // Decrease SelectedColor opacity to mute it.
           ctx.fillStyle = selectedColor.concat(muteOpacity);
-          ctx.fillRect(
-            bar.left,
-            bar.top,
-            bar.width,
-            barHeight,
-          );
+          ctx.fillRect(bar.left, bar.top, bar.width, barHeight);
+          const featureWidth = (bar.width / (bar.length - 1)) * overflow;
           // Draw bright markers for the keyframes
           ctx.fillStyle = selectedColor;
           bar.markers

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -146,7 +146,7 @@ export default {
       }
       canvas.width = this.clientWidth;
       canvas.height = bars.slice(-1)[0].top + 15;
-      const muteOpacity = '30'; // Hex string: how much to mute regular colors
+      const muteOpacity = '30'; // Hex string: how much to mute regular colors: '#RRGGBB[AA]'
       const selectedColor = this.$vuetify.theme.themes.dark.accent;
       const overflow = 0.6; // How much of a frame-width each detection box should occupy
       const barHeight = 10;

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -31,11 +31,8 @@ export default {
       required: true,
     },
     data: {
-      type: Array,
+      type: Object,
       required: true,
-      validator(data) {
-        return !data.find((datum) => !datum.range);
-      },
     },
   },
   data() {
@@ -48,7 +45,7 @@ export default {
   },
   computed: {
     barData() {
-      const sorted = sortBy(this.data, (data) => data.range[0]);
+      const sorted = sortBy(this.data.values, (data) => data.range[0]);
       const bars = [];
       sorted.forEach((event) => {
         for (let i = 0, n = bars.length; i < n; i += 1) {
@@ -90,7 +87,7 @@ export default {
               const left = x(event.range[0]);
               bars.push({
                 left,
-                width: Math.max(x(event.range[1]) - left, 3),
+                width: (x(event.range[1]) - left) || x(1),
                 top: i * 15 + 3,
                 color: event.color,
                 selected: event.selected,
@@ -149,63 +146,49 @@ export default {
       }
       canvas.width = this.clientWidth;
       canvas.height = bars.slice(-1)[0].top + 15;
-      const overflow = 1.1; // CHANGE to > ~1.05 if you want overlapping or not keyframes
-      let selectedBar = null;
+      const muteOpacity = '30'; // Hex string: how much to mute regular colors
+      const selectedColor = this.$vuetify.theme.themes.dark.accent;
+      const overflow = 0.6; // How much of a frame-width each detection box should occupy
+      const barHeight = 10;
       bars.forEach((bar) => {
-        const typeColor = bar.color ? bar.color : '#4c9ac2';
-        if (bar.selected) {
-          //Save the selectedBar for drawing after all other are complete
-          selectedBar = bar;
+        const featureWidth = (bar.width / (bar.length - 1)) * overflow;
+        if (!bar.selected) {
+          // If this bar is not selected
+          const typeColor = bar.color ? bar.color : '#4c9ac2';
+          const typeColorMuted = typeColor.concat(muteOpacity);
+          ctx.fillStyle = this.data.muted
+            ? typeColorMuted
+            : typeColor;
+          ctx.fillRect(bar.left, bar.top, bar.width, barHeight);
+        } else if (bar.length === bar.markers.length - 1) {
+          // Else if Keyframe density is 100%
+          ctx.fillStyle = selectedColor;
+          ctx.fillRect(bar.left, bar.top, bar.width, barHeight);
         } else {
-          ctx.fillStyle = typeColor;
+          // Else draw individual feature frame segments
+          // Decrease SelectedColor opacity to mute it.
+          ctx.fillStyle = selectedColor.concat(muteOpacity);
           ctx.fillRect(
             bar.left,
             bar.top,
             bar.width,
-            10,
+            barHeight,
           );
-        }
-      });
-      if (selectedBar) {
-        //draw screen
-        ctx.fillStyle = '#000000DD'; //black with opacity
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        const bar = selectedBar;
-        const typeColor = bar.color ? bar.color : '#4c9ac2';
-        const width = (bar.width / (bar.length - 1)) * overflow;
-        ctx.fillStyle = typeColor;
-        ctx.lineWidth = 2;
-        //Draw the background rect color
-        ctx.fillRect(
-          bar.left - width / 2.0,
-          bar.top,
-          bar.width,
-          10,
-        );
-        //Only complicate drawing if there are less markers than total frames in a bar
-        if (bar.length !== bar.markers.length - 1) {
-        //Draw a screen over the color to mute it
-          ctx.fillStyle = '#00000088'; //black with opacity
-          ctx.fillRect(
-            bar.left,
-            bar.top,
-            bar.width,
-            10,
-          );
-          //Draw the markers for the keyframes
-          ctx.fillStyle = typeColor;
-          let widthDivisor = 1;
+          // Draw bright markers for the keyframes
+          ctx.fillStyle = selectedColor;
           bar.markers
             .map((n) => this.x(n))
-            .slice(0, bar.markers.length)
-            .forEach((m, i) => {
-              if (i === bar.markers.length - 1) {
-                widthDivisor = 2.0;
-              }
-              ctx.fillRect(m - width / 2.0, bar.top, width / widthDivisor, 10);
+            .forEach((m) => {
+              ctx.fillRect(
+                // offset frame back 1/2 width so the cursor falls in the middle
+                m - (featureWidth / 2),
+                bar.top,
+                featureWidth,
+                barHeight,
+              );
             });
         }
-      }
+      });
     },
     mousemove(e) {
       this.tooltip = null;

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -25,6 +25,7 @@ export default function useEventChart({
   const eventChartData = computed(() => {
     const values = [] as EventChartData[];
     const mapfunc = typeStyling.value.color;
+    const selectedTrackIdValue = selectedTrackId.value;
     /* use forEach rather than filter().map() to save an interation */
     enabledTrackIds.value.forEach((trackId) => {
       const track = trackMap.get(trackId);
@@ -38,13 +39,16 @@ export default function useEventChart({
           trackId,
           name: `Track ${trackId}`,
           color: mapfunc(trackType),
-          selected: trackId === selectedTrackId.value,
+          selected: trackId === selectedTrackIdValue,
           range: [track.begin, track.end],
           markers: track.featureIndex,
         });
       }
     });
-    return values;
+    return {
+      muted: selectedTrackIdValue !== null,
+      values,
+    };
   });
 
   return { eventChartData };


### PR DESCRIPTION
![Screenshot from 2020-07-02 14-45-22](https://user-images.githubusercontent.com/4214172/86397891-af34fb00-bc72-11ea-9aeb-69b146fb39d8.png)

I generally liked what you did here.   This PR makes a few subtle changes.

* Generally clean up logic, add better variable names, comments, etc.  I tried to fill in comments when I spent more than a few seconds thinking "What does this do?"
* Before, a black shade was being drawn that caused conttrast with the rest of the event bar.  It was easier just do not draw the shade and mute the colors of the individual bars, keeping the background transparent.  I found that painting less layers also made things look a little sharper.
* Adds `muted` field to data prop to tell the component when a selected bar is present and the rest should be muted
* Makes the overflow value `0.6` to show feature segments.
* Removed the WidthDivisor bits, since the frame overhang on boundaries gives nice definition to a selected track (and it sorta looks weird when they aren't the same width as all the others).

LMK what you think.  
