### PR TITLE
Minor Styling updates

### DIFF
--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -181,26 +181,6 @@ export default Vue.extend({
             v-else
             class="newTrackSettings"
           >
-            <v-tooltip
-              open-delay="200"
-              bottom
-              max-width="200"
-            >
-              <template #activator="{ on }">
-                <v-btn
-                  outlined
-                  x-small
-                  :color="newTrackColor"
-                  v-on="on"
-                  @click="$emit('track-add')"
-                >
-                  {{ newTrackSettings.value.mode }}<v-icon small>
-                    mdi-plus
-                  </v-icon>
-                </v-btn>
-              </template>
-              <span>Default Type: {{ newTrackSettings.value.type }}</span>
-            </v-tooltip>
             <v-btn
               icon
               small
@@ -214,6 +194,27 @@ export default Vue.extend({
                 mdi-settings
               </v-icon>
             </v-btn>
+            <v-tooltip
+              open-delay="200"
+              bottom
+              max-width="200"
+            >
+              <template #activator="{ on }">
+                <v-btn
+                  outlined
+                  x-small
+                  :color="newTrackColor"
+                  v-on="on"
+                  @click="$emit('track-add')"
+                >
+                  <v-icon small>
+                    mdi-plus
+                  </v-icon>
+                  {{ newTrackSettings.value.mode }}
+                </v-btn>
+              </template>
+              <span>Default Type: {{ newTrackSettings.value.type }}</span>
+            </v-tooltip>
           </div>
         </v-row>
         <v-row>

--- a/client/src/components/UserGuideDialog.vue
+++ b/client/src/components/UserGuideDialog.vue
@@ -46,6 +46,9 @@ export default {
           name: 'Editing',
           data: [
             {
+              name: 'New Track', icon: 'mdi-keyboard', actions: ['N Key'], description: 'Create a new Track/Detection',
+            },
+            {
               name: 'Edit Track', icon: 'mdi-mouse', actions: ['Right Click Mouse'], description: 'Right click a track to enter Edit Mode',
             },
             {


### PR DESCRIPTION
Fixes #200  - changes the detection+ to +detection/track now and reorders where the settings icon is.
Fixes #201  - adds a shortcut key to the inline documentation.  I have a current Google Doc that I need to transfer to the wiki for more in-depth documentation of the entire interface.  Getting this merged first would help with any newer screenshots that are needed.
![image](https://user-images.githubusercontent.com/61746913/86621509-51fbbb00-bf8c-11ea-81a4-4a8a1d59043d.png)
![image](https://user-images.githubusercontent.com/61746913/86621828-e2d29680-bf8c-11ea-92fa-17695df407ab.png)
![image](https://user-images.githubusercontent.com/61746913/86621853-f0881c00-bf8c-11ea-8c83-5085b4ba0df5.png)

