### PR TITLE
Continue if build failed, send failure report

### DIFF
--- a/docker/ansible/.gitignore
+++ b/docker/ansible/.gitignore
@@ -1,0 +1,1 @@
+.vars.yml

--- a/docker/ansible/.vars.example.yml
+++ b/docker/ansible/.vars.example.yml
@@ -1,0 +1,4 @@
+---
+deploy_email_address: address.to.send.from@gmail.com
+notify_email_address: address.to.send.to@gmail.com
+

--- a/docker/ansible/README.md
+++ b/docker/ansible/README.md
@@ -25,3 +25,8 @@ ansible-playbook docker/ansible/clean.systemd.yml
 
 # Operation
 Once the service is initiated, it will run the `deploy.yml` playbook at the interval specified in `viame-deploy.timer`. This will update the server with any changes.
+
+`deploy.yml` will read in variables from `.vars.yml`. These are not tracked in source control, as they're assumed to contain sensitive information. The following variables are expected to be defined in `.vars.yml`:
+
+- `deploy_email_address` - The email address that the emails will be sent from
+- `notify_email_address` - The email address that the emails will be sent to

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -23,8 +23,8 @@
     - name: Send email on build failure
       when: register.rc != 0
       mail:
-        from: {{ deploy_email_address }}
-        to: {{ notify_email_address  }}
+        from: "{{ deploy_email_address }}"
+        to: "{{ notify_email_address  }}"
         subject: Failed Build of Viame-Web
         body: |
           Captured stdout:

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -4,18 +4,36 @@
   vars:
     # Required to use docker_compose properly
     ansible_python_interpreter: /usr/bin/python3
+  vars_files:
+      - ".vars.yml"
   tasks:
-    - name: Stop Currently Running Service
-      docker_compose:
-        project_src: /home/viame/docker
-        state: absent
-
     - name: Pull Repository Changes
       shell: git pull
       args:
         chdir: /home/viame
 
-    - name: Restart and Build Service
+    - name: Stop and Build Service
+      ignore_errors: yes
+      register: build
       docker_compose:
         project_src: /home/viame/docker
         build: yes
+        state: absent
+
+    - name: Send email on build failure
+      when: register.rc != 0
+      mail:
+        from: {{ deploy_email_address }}
+        to: {{ notify_email_address  }}
+        subject: Failed Build of Viame-Web
+        body: |
+          Captured stdout:
+          {{ build.stdout  }}
+
+          Captured stderr:
+          {{ build.stderr  }}
+
+    - name: Start Service
+      docker_compose:
+        project_src: /home/viame/docker
+        state: present


### PR DESCRIPTION
Fixes #231 

This updates the behavior of the builds to start the service independent of building, so that if it fails, the service can come back online without issue. Furthermore, if the build fails, it will send a failure report to the email address we specify.