### PR TITLE
Track typename fix

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -47,7 +47,6 @@ export default {
       skipOnFocus: false,
     };
   },
-
   computed: {
     isTrack() {
       return this.track.length > 1 || this.feature.shouldInterpolate;
@@ -94,6 +93,11 @@ export default {
         shouldInterpolate: false,
         isKeyframe: false,
       };
+    },
+  },
+  watch: {
+    trackType(val) {
+      this.value = val;
     },
   },
   methods: {

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -15,7 +15,6 @@ export default {
   data() {
     return {
       loadingVideo: false,
-      observer: null,
     };
   },
   created() {
@@ -37,20 +36,6 @@ export default {
         img.cached = true;
         this.init();
       };
-    }
-  },
-  mounted() {
-    //Adjusts the size to fix the geoMap display if any of the contents sizes change.
-    if (this.$refs.container) {
-      this.observer = new ResizeObserver(() => {
-        this.onResize();
-      });
-      this.observer.observe(this.$refs.container);
-    }
-  },
-  beforeDestroy() {
-    if (this.observer) {
-      this.observer.unobserve(this.$refs.container);
     }
   },
   methods: {
@@ -101,17 +86,6 @@ export default {
     pause() {
       this.playing = false;
       this.loadingVideo = false;
-    },
-
-    onResize() {
-      if (!this.geoViewer) {
-        return;
-      }
-      const size = this.$refs.container.getBoundingClientRect();
-      const mapSize = this.geoViewer.size();
-      if (size.width !== mapSize.width || size.height !== mapSize.height) {
-        this.geoViewer.size(size);
-      }
     },
     /**
      * Handles playback of the image sequence
@@ -255,7 +229,6 @@ export default {
 
 <template>
   <div
-    v-resize="onResize"
     class="video-annotator"
   >
     <div

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -17,6 +17,7 @@ export default {
       loadingVideo: false,
     };
   },
+
   created() {
     // Below are configuration settings we can set until we decide on good numbers to utilize.
     this.playCache = 1; // seconds required to be fully cached before playback
@@ -38,7 +39,6 @@ export default {
       };
     }
   },
-
   methods: {
     init() {
       this.baseInit(); // Mixin method
@@ -262,7 +262,11 @@ export default {
         </v-progress-circular>
       </div>
     </div>
-    <slot name="control" />
+    <slot
+      ref="control"
+      name="control"
+      @resize="onResize"
+    />
     <slot v-if="ready" />
   </div>
 </template>

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -15,9 +15,9 @@ export default {
   data() {
     return {
       loadingVideo: false,
+      observer: null,
     };
   },
-
   created() {
     // Below are configuration settings we can set until we decide on good numbers to utilize.
     this.playCache = 1; // seconds required to be fully cached before playback
@@ -37,6 +37,20 @@ export default {
         img.cached = true;
         this.init();
       };
+    }
+  },
+  mounted() {
+    //Adjusts the size to fix the geoMap display if any of the contents sizes change.
+    if (this.$refs.container) {
+      this.observer = new ResizeObserver(() => {
+        this.onResize();
+      });
+      this.observer.observe(this.$refs.container);
+    }
+  },
+  beforeDestroy() {
+    if (this.observer) {
+      this.observer.unobserve(this.$refs.container);
     }
   },
   methods: {

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -33,7 +33,20 @@ export default {
     };
     video.addEventListener('pause', this.videoPaused);
   },
-
+  mounted() {
+    //Adjusts the size to fix the geoMap display if any of the contents sizes change.
+    if (this.$refs.container) {
+      this.observer = new ResizeObserver(() => {
+        this.onResize();
+      });
+      this.observer.observe(this.$refs.container);
+    }
+  },
+  beforeDestroy() {
+    if (this.observer) {
+      this.observer.unobserve(this.$refs.container);
+    }
+  },
   methods: {
     init() {
       this.baseInit(); // Mixin method

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -33,20 +33,6 @@ export default {
     };
     video.addEventListener('pause', this.videoPaused);
   },
-  mounted() {
-    //Adjusts the size to fix the geoMap display if any of the contents sizes change.
-    if (this.$refs.container) {
-      this.observer = new ResizeObserver(() => {
-        this.onResize();
-      });
-      this.observer.observe(this.$refs.container);
-    }
-  },
-  beforeDestroy() {
-    if (this.observer) {
-      this.observer.unobserve(this.$refs.container);
-    }
-  },
   methods: {
     init() {
       this.baseInit(); // Mixin method

--- a/client/src/components/annotators/annotator.js
+++ b/client/src/components/annotators/annotator.js
@@ -31,6 +31,7 @@ export default {
       frame: 0,
       maxFrame: 0,
       syncedFrame: 0,
+      observer: null,
     };
   },
   created() {
@@ -41,6 +42,20 @@ export default {
     this.provided.$on('seek', this.seek);
     this.emitFrame();
     this.emitFrame = throttle(this.emitFrame, 200);
+  },
+  mounted() {
+    //Adjusts the size to fix the geoMap display if any of the contents sizes change.
+    if (this.$refs.container) {
+      this.observer = new ResizeObserver(() => {
+        this.onResize();
+      });
+      this.observer.observe(this.$refs.container);
+    }
+  },
+  beforeDestroy() {
+    if (this.observer) {
+      this.observer.unobserve(this.$refs.container);
+    }
   },
   methods: {
     baseInit() {
@@ -95,6 +110,16 @@ export default {
       const targetFrame = this.frame + 1;
       if (targetFrame <= this.maxFrame) {
         this.seek(targetFrame);
+      }
+    },
+    onResize() {
+      if (!this.geoViewer) {
+        return;
+      }
+      const size = this.$refs.container.getBoundingClientRect();
+      const mapSize = this.geoViewer.size();
+      if (size.width !== mapSize.width || size.height !== mapSize.height) {
+        this.geoViewer.size(size);
       }
     },
     emitFrame() {

--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -76,43 +76,68 @@ export default {
             @input="input"
           />
         </v-row>
-        <v-row>
-          <v-spacer />
-          <v-btn
-            icon
-            small
-            title="Left key"
-            @click="previousFrame"
+        <v-row dense>
+          <v-col
+            class="pl-0"
+            align="left"
+            cols="4"
+            md="4"
+            sm="6"
+            xs="8"
           >
-            <v-icon>mdi-skip-previous</v-icon>
-          </v-btn>
-          <v-btn
-            v-if="!annotator.playing"
-            icon
-            small
-            title="Space key"
-            @click="annotator.$emit('play')"
+            <slot
+              justify="start"
+              name="timelineControls"
+            />
+          </v-col>
+          <v-col
+            align="center"
+            cols="4"
+            md="4"
+            sm="4"
+            xs="4"
           >
-            <v-icon>mdi-play</v-icon>
-          </v-btn>
-          <v-btn
-            v-else
-            icon
-            small
-            title="Space key"
-            @click="annotator.$emit('pause')"
-          >
-            <v-icon>mdi-pause</v-icon>
-          </v-btn>
-          <v-btn
-            icon
-            small
-            title="Right key"
-            @click="nextFrame"
-          >
-            <v-icon>mdi-skip-next</v-icon>
-          </v-btn>
-          <v-spacer />
+            <v-btn
+              icon
+              small
+              title="Left key"
+              @click="previousFrame"
+            >
+              <v-icon>mdi-skip-previous</v-icon>
+            </v-btn>
+            <v-btn
+              v-if="!annotator.playing"
+              icon
+              small
+              title="Space key"
+              @click="annotator.$emit('play')"
+            >
+              <v-icon>mdi-play</v-icon>
+            </v-btn>
+            <v-btn
+              v-else
+              icon
+              small
+              title="Space key"
+              @click="annotator.$emit('pause')"
+            >
+              <v-icon>mdi-pause</v-icon>
+            </v-btn>
+            <v-btn
+              icon
+              small
+              title="Right key"
+              @click="nextFrame"
+            >
+              <v-icon>mdi-skip-next</v-icon>
+            </v-btn>
+          </v-col>
+          <v-col
+            cols="4"
+            md="4"
+            sm="2"
+            xs="0"
+          />
         </v-row>
       </v-container>
     </v-toolbar>

--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -76,9 +76,9 @@ export default {
             @input="input"
           />
         </v-row>
-        <v-row dense>
+        <v-row class="controls-row">
           <v-col
-            class="pl-0"
+            class="pl-1"
             align="left"
             cols="4"
             md="4"
@@ -93,9 +93,6 @@ export default {
           <v-col
             align="center"
             cols="4"
-            md="4"
-            sm="4"
-            xs="4"
           >
             <v-btn
               icon
@@ -143,3 +140,9 @@ export default {
     </v-toolbar>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.controls-row {
+  min-width:420px;
+}
+</style>

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -226,7 +226,8 @@ export default {
       const bar = this.bars
         .filter((b) => b.top === top)
         .reverse()
-        .find((b) => b.left < offsetX && b.right - b.left > offsetX);
+        .find((b) => b.left < offsetX
+        && (b.right - b.left > offsetX || b.left + b.minWidth > offsetX));
       if (!bar) {
         return;
       }

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -165,6 +165,7 @@ export default {
           // Else if Keyframe density is 100%
           ctx.fillStyle = selectedColor;
           ctx.fillRect(bar.left, bar.top, barWidth, barHeight);
+          this.scrollToElement(bar);
         } else {
           // Else draw individual feature frame segments
           // Decrease SelectedColor opacity to mute it.
@@ -193,8 +194,20 @@ export default {
                 ctx.stroke();
               }
             });
+          this.scrollToElement(bar);
         }
       });
+    },
+    scrollToElement(selectedBar) {
+      const eventChart = this.$refs.canvas.parentNode;
+      const { offsetHeight } = eventChart;
+      const { scrollTop } = eventChart;
+      const { top } = selectedBar;
+      if (top > offsetHeight) {
+        eventChart.scrollTop = top + offsetHeight / 2.0;
+      } else if (scrollTop > top) {
+        eventChart.scrollTop = 0.0;
+      }
     },
     mousemove(e) {
       this.tooltip = null;

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -222,11 +222,11 @@ export default {
       if (remainder > 10) {
         return;
       }
-      const top = offsetY - (offsetY % 15);
+      const top = offsetY - (offsetY % 15) + 3;
       const bar = this.bars
         .filter((b) => b.top === top)
         .reverse()
-        .find((b) => b.left < offsetX && b.left + b.width > offsetX);
+        .find((b) => b.left < offsetX && b.right - b.left > offsetX);
       if (!bar) {
         return;
       }
@@ -274,7 +274,7 @@ export default {
     border: 1px solid white;
     padding: 0px 5px;
     font-size: 14px;
-    z-index: 1;
+    z-index: 2;
   }
 }
 </style>

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -30,6 +30,10 @@ export default {
       type: Number,
       required: true,
     },
+    margin: {
+      type: Number,
+      default: 0,
+    },
     data: {
       type: Object,
       required: true,
@@ -84,7 +88,7 @@ export default {
               [event.range[0], event.range[1]],
             ))
             .forEach((event) => {
-              const frameWidth = x(this.startFrame_ + 1) * 0.6;
+              const frameWidth = (x(this.startFrame_ + 1) - x(this.startFrame_)) * 0.6;
               bars.push({
                 left: x(event.range[0]),
                 right: x(event.range[1]),
@@ -131,7 +135,7 @@ export default {
       const x = d3
         .scaleLinear()
         .domain([this.startFrame_, this.endFrame_])
-        .range([0, width]);
+        .range([this.margin, width]);
       this.x = x;
     },
     update() {

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -25,6 +25,10 @@ export default {
       type: Number,
       required: true,
     },
+    margin: {
+      type: Number,
+      default: 0,
+    },
     data: {
       type: Array,
       required: true,
@@ -80,7 +84,7 @@ export default {
       const x = d3
         .scaleLinear()
         .domain([this.startFrame, this.endFrame])
-        .range([0, width]);
+        .range([this.margin, width]);
       this.x = x;
       const max = d3.max(this.data, (datum) => d3.max(datum.values, (d) => d[1]));
       const y = d3
@@ -111,7 +115,7 @@ export default {
         .call(axis)
         .call((g) => g
           .selectAll('.tick text')
-          .attr('x', 0)
+          .attr('x', -5)
           .attr('dx', 13));
 
       const path = svg

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -13,6 +13,10 @@ export default {
       type: Number,
       default: 0,
     },
+    display: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -67,6 +71,13 @@ export default {
         this.endFrame = Math.min(frame + 200, this.maxFrame);
       } else if (frame < this.startFrame) {
         this.startFrame = Math.max(frame - 100, 0);
+      }
+    },
+    display(val) {
+      if (!val) {
+        this.clientHeight = 0;
+      } else {
+        this.initialize();
       }
     },
   },

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -23,6 +23,7 @@ export default {
       timelineScale: null,
       clientWidth: 0,
       clientHeight: 0,
+      margin: 20,
     };
   },
   computed: {
@@ -41,7 +42,7 @@ export default {
         return null;
       }
       return Math.round(
-        this.$refs.workarea.clientWidth
+        this.margin + (this.clientWidth - this.margin)
           * ((this.frame - this.startFrame) / (this.endFrame - this.startFrame)),
       );
     },
@@ -85,13 +86,13 @@ export default {
       const width = this.$refs.workarea.clientWidth || 0;
       const height = this.$refs.workarea.clientHeight || 0;
       // clientWidth and clientHeight are properties used to resize child elements
-      this.clientWidth = width;
+      this.clientWidth = width - this.margin;
       // Timeline height needs to offset so it doesn't overlap the frame number
       this.clientHeight = height - 15;
       const scale = d3
         .scaleLinear()
         .domain([0, this.maxFrame])
-        .range([0, width]);
+        .range([this.margin, this.clientWidth]);
       this.timelineScale = scale;
       const axis = d3
         .axisTop()
@@ -105,7 +106,7 @@ export default {
           .append('svg');
       }
       this.svg.style('display', 'block')
-        .attr('width', width)
+        .attr('width', this.clientWidth)
         .attr('height', height);
       if (!this.g) {
         this.g = this.svg.append('g')
@@ -147,8 +148,8 @@ export default {
     },
     emitSeek(e) {
       const frame = Math.round(
-        ((e.clientX - this.$refs.workarea.getBoundingClientRect().left)
-          / this.$refs.workarea.clientWidth)
+        ((e.clientX - (this.$refs.workarea.getBoundingClientRect().left + 20))
+          / (this.clientWidth - this.margin))
           * (this.endFrame - this.startFrame)
           + this.startFrame,
       );
@@ -190,7 +191,7 @@ export default {
         return;
       }
       const delta = this.minimapDraggingStartClientX - e.clientX;
-      const frameDelta = (delta / this.$refs.minimap.clientWidth) * this.maxFrame;
+      const frameDelta = (delta / this.clientWidth) * this.maxFrame;
       const startFrame = this.minimapDraggingStartFrame - frameDelta;
       if (startFrame < 0) {
         return;
@@ -239,6 +240,7 @@ export default {
           :maxFrame="maxFrame"
           :clientWidth="clientWidth"
           :clientHeight="clientHeight"
+          :margin="margin"
         />
       </div>
     </div>

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -34,23 +34,21 @@ export default defineComponent({
     },
   },
 
-  setup(props, { emit }) {
+  setup() {
     const showDetectionView = ref(true);
     const showEventView = ref(false);
 
-    function toggleView(type: string) {
-      if (!showDetectionView.value && !showEventView.value) {
-        emit('resize');
-      }
+    /**
+     * Toggles on and off the individual timeline views
+     * Resizing is handled by the Annator itself.
+     */
+    function toggleView(type: 'Detection' | 'Event') {
       if (type === 'Detection') {
         showDetectionView.value = !showDetectionView.value;
         showEventView.value = false;
       } else if (type === 'Event') {
         showEventView.value = !showEventView.value;
         showDetectionView.value = false;
-      }
-      if (!showDetectionView.value && !showEventView.value) {
-        emit('resize');
       }
     }
     return {
@@ -69,7 +67,6 @@ export default defineComponent({
       <v-btn
         :outlined="showDetectionView"
         x-small
-        class="toggle-timeline-button-detection"
         tab-index="-1"
         @click="toggleView('Detection')"
       >
@@ -78,7 +75,6 @@ export default defineComponent({
       <v-btn
         :outlined="showEventView"
         x-small
-        class="toggle-timeline-button-event"
         tab-index="-1"
         @click="toggleView('Event')"
       >

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -79,6 +79,7 @@ export default defineComponent({
           </v-tooltip>
           <v-btn
             class="mx-2"
+            :class="{'timeline-button':currentView!=='Detections' || collapsed}"
             depressed
             :outlined="currentView==='Detections' && !collapsed"
             x-small
@@ -89,6 +90,7 @@ export default defineComponent({
           </v-btn>
           <v-btn
             class="mx-2"
+            :class="{'timeline-button':currentView!=='Events' || collapsed}"
             depressed
             :outlined="currentView==='Events' && !collapsed"
             x-small
@@ -144,5 +146,8 @@ export default defineComponent({
   </div>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
+.timeline-button {
+    border: thin solid transparent;
+}
 </style>

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -34,9 +34,29 @@ export default defineComponent({
     },
   },
 
-  setup() {
+  setup(props, { emit }) {
+    const showDetectionView = ref(true);
+    const showEventView = ref(false);
+
+    function toggleView(type: string) {
+      if (!showDetectionView.value && !showEventView.value) {
+        emit('resize');
+      }
+      if (type === 'Detection') {
+        showDetectionView.value = !showDetectionView.value;
+        showEventView.value = false;
+      } else if (type === 'Event') {
+        showEventView.value = !showEventView.value;
+        showDetectionView.value = false;
+      }
+      if (!showDetectionView.value && !showEventView.value) {
+        emit('resize');
+      }
+    }
     return {
-      showTrackView: ref(false),
+      showDetectionView,
+      showEventView,
+      toggleView,
     };
   },
 });
@@ -45,11 +65,32 @@ export default defineComponent({
 <template>
   <div>
     <Controls />
-    <timeline-wrapper>
+    <div class="timeline-buttons">
+      <v-btn
+        :outlined="showDetectionView"
+        x-small
+        class="toggle-timeline-button-detection"
+        tab-index="-1"
+        @click="toggleView('Detection')"
+      >
+        Detection
+      </v-btn>
+      <v-btn
+        :outlined="showEventView"
+        x-small
+        class="toggle-timeline-button-event"
+        tab-index="-1"
+        @click="toggleView('Event')"
+      >
+        Events
+      </v-btn>
+    </div>
+    <timeline-wrapper v-if="(showDetectionView || showEventView)">
       <template #default="{ maxFrame, frame, seek }">
         <Timeline
           :max-frame="maxFrame"
           :frame="frame"
+          :display="(showDetectionView || showEventView)"
           @seek="seek"
         >
           <template
@@ -63,7 +104,7 @@ export default defineComponent({
             }"
           >
             <line-chart
-              v-if="!showTrackView"
+              v-if="showDetectionView"
               :start-frame="startFrame"
               :end-frame="endFrame"
               :max-frame="childMaxFrame"
@@ -73,7 +114,7 @@ export default defineComponent({
               :margin="margin"
             />
             <event-chart
-              v-else
+              v-if="showEventView"
               :start-frame="startFrame"
               :end-frame="endFrame"
               :max-frame="childMaxFrame"
@@ -82,15 +123,6 @@ export default defineComponent({
               :margin="margin"
             />
           </template>
-          <v-btn
-            outlined
-            x-small
-            class="toggle-timeline-button"
-            tab-index="-1"
-            @click="showTrackView = !showTrackView"
-          >
-            {{ showTrackView ? "Detection" : "Track" }}
-          </v-btn>
         </Timeline>
       </template>
     </timeline-wrapper>
@@ -98,9 +130,9 @@ export default defineComponent({
 </template>
 
 <style scoped>
-.toggle-timeline-button {
-  position: absolute;
-  top: -24px;
-  left: 2px;
+.timeline-buttons{
+  position:relative;
+  top:-24px;
+  margin-bottom:-24px;
 }
 </style>

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -37,27 +37,19 @@ export default defineComponent({
   },
 
   setup() {
-    const showDetectionView = ref(true);
-    const showEventView = ref(false);
+    const currentView = ref('Detections');
     const collapsed = ref(false);
 
     /**
      * Toggles on and off the individual timeline views
      * Resizing is handled by the Annator itself.
      */
-    function toggleView(type: 'Detection' | 'Event') {
-      if (type === 'Detection') {
-        showDetectionView.value = true;
-        showEventView.value = false;
-      } else if (type === 'Event') {
-        showEventView.value = true;
-        showDetectionView.value = false;
-      }
+    function toggleView(type: 'Detections' | 'Events') {
+      currentView.value = type;
       collapsed.value = false;
     }
     return {
-      showDetectionView,
-      showEventView,
+      currentView,
       toggleView,
       collapsed,
     };
@@ -77,19 +69,19 @@ export default defineComponent({
       />
       <v-btn
         class="mx-2"
-        :outlined="showDetectionView"
+        :outlined="currentView==='Detections' && !collapsed"
         x-small
         tab-index="-1"
-        @click="toggleView('Detection')"
+        @click="toggleView('Detections')"
       >
         Detections
       </v-btn>
       <v-btn
         class="mx-2"
-        :outlined="showEventView"
+        :outlined="currentView==='Events' && !collapsed"
         x-small
         tab-index="-1"
-        @click="toggleView('Event')"
+        @click="toggleView('Events')"
       >
         Events
       </v-btn>
@@ -99,7 +91,7 @@ export default defineComponent({
         <Timeline
           :max-frame="maxFrame"
           :frame="frame"
-          :display="(showDetectionView || showEventView)"
+          :display="!collapsed"
           @seek="seek"
         >
           <template
@@ -113,7 +105,7 @@ export default defineComponent({
             }"
           >
             <line-chart
-              v-if="showDetectionView"
+              v-if="currentView==='Detections'"
               :start-frame="startFrame"
               :end-frame="endFrame"
               :max-frame="childMaxFrame"
@@ -123,7 +115,7 @@ export default defineComponent({
               :margin="margin"
             />
             <event-chart
-              v-if="showEventView"
+              v-if="currentView==='Events'"
               :start-frame="startFrame"
               :end-frame="endFrame"
               :max-frame="childMaxFrame"

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -13,6 +13,7 @@ import TimelineWrapper from '@/components/controls/TimelineWrapper.vue';
 import Timeline from '@/components/controls/Timeline.vue';
 import LineChart from '@/components/controls/LineChart.vue';
 import EventChart from '@/components/controls/EventChart.vue';
+import TooltipBtn from '@/components/TooltipButton.vue';
 
 export default defineComponent({
   components: {
@@ -21,6 +22,7 @@ export default defineComponent({
     LineChart,
     Timeline,
     TimelineWrapper,
+    TooltipBtn,
   },
 
   props: {
@@ -37,6 +39,7 @@ export default defineComponent({
   setup() {
     const showDetectionView = ref(true);
     const showEventView = ref(false);
+    const collapsed = ref(false);
 
     /**
      * Toggles on and off the individual timeline views
@@ -44,17 +47,19 @@ export default defineComponent({
      */
     function toggleView(type: 'Detection' | 'Event') {
       if (type === 'Detection') {
-        showDetectionView.value = !showDetectionView.value;
+        showDetectionView.value = true;
         showEventView.value = false;
       } else if (type === 'Event') {
-        showEventView.value = !showEventView.value;
+        showEventView.value = true;
         showDetectionView.value = false;
       }
+      collapsed.value = false;
     }
     return {
       showDetectionView,
       showEventView,
       toggleView,
+      collapsed,
     };
   },
 });
@@ -64,15 +69,23 @@ export default defineComponent({
   <div>
     <Controls />
     <div class="timeline-buttons">
+      <tooltip-btn
+        class="mx-2"
+        :icon="collapsed?'mdi-chevron-up-box-outline': 'mdi-chevron-down-box-outline'"
+        tooltip-text="Collapse/Expand Timeline"
+        @click="collapsed=!collapsed"
+      />
       <v-btn
+        class="mx-2"
         :outlined="showDetectionView"
         x-small
         tab-index="-1"
         @click="toggleView('Detection')"
       >
-        Detection
+        Detections
       </v-btn>
       <v-btn
+        class="mx-2"
         :outlined="showEventView"
         x-small
         tab-index="-1"
@@ -81,7 +94,7 @@ export default defineComponent({
         Events
       </v-btn>
     </div>
-    <timeline-wrapper v-if="(showDetectionView || showEventView)">
+    <timeline-wrapper v-if="(!collapsed)">
       <template #default="{ maxFrame, frame, seek }">
         <Timeline
           :max-frame="maxFrame"
@@ -130,6 +143,6 @@ export default defineComponent({
   position:relative;
   top:-24px;
   margin-bottom:-24px;
-  width: 150px;
+  width: 250px;
 }
 </style>

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -59,6 +59,7 @@ export default defineComponent({
               maxFrame: childMaxFrame,
               clientWidth,
               clientHeight,
+              margin,
             }"
           >
             <line-chart
@@ -69,6 +70,7 @@ export default defineComponent({
               :data="lineChartData.value"
               :client-width="clientWidth"
               :client-height="clientHeight"
+              :margin="margin"
             />
             <event-chart
               v-else
@@ -77,6 +79,7 @@ export default defineComponent({
               :max-frame="childMaxFrame"
               :data="eventChartData.value"
               :client-width="clientWidth"
+              :margin="margin"
             />
           </template>
           <v-btn

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -59,33 +59,47 @@ export default defineComponent({
 
 <template>
   <div>
-    <Controls />
-    <div class="timeline-buttons">
-      <tooltip-btn
-        class="mx-2"
-        :icon="collapsed?'mdi-chevron-up-box-outline': 'mdi-chevron-down-box-outline'"
-        tooltip-text="Collapse/Expand Timeline"
-        @click="collapsed=!collapsed"
-      />
-      <v-btn
-        class="mx-2"
-        :outlined="currentView==='Detections' && !collapsed"
-        x-small
-        tab-index="-1"
-        @click="toggleView('Detections')"
-      >
-        Detections
-      </v-btn>
-      <v-btn
-        class="mx-2"
-        :outlined="currentView==='Events' && !collapsed"
-        x-small
-        tab-index="-1"
-        @click="toggleView('Events')"
-      >
-        Events
-      </v-btn>
-    </div>
+    <Controls>
+      <template slot="timelineControls">
+        <div>
+          <v-tooltip
+            open-delay="200"
+            bottom
+          >
+            <template #activator="{ on }">
+              <v-icon
+                small
+                v-on="on"
+                @click="collapsed=!collapsed"
+              >
+                {{ collapsed?'mdi-chevron-up-box': 'mdi-chevron-down-box' }}
+              </v-icon>
+            </template>
+            <span>Collapse/Expand Timeline</span>
+          </v-tooltip>
+          <v-btn
+            class="mx-2"
+            depressed
+            :outlined="currentView==='Detections' && !collapsed"
+            x-small
+            tab-index="-1"
+            @click="toggleView('Detections')"
+          >
+            Detections
+          </v-btn>
+          <v-btn
+            class="mx-2"
+            depressed
+            :outlined="currentView==='Events' && !collapsed"
+            x-small
+            tab-index="-1"
+            @click="toggleView('Events')"
+          >
+            Events
+          </v-btn>
+        </div>
+      </template>
+    </Controls>
     <timeline-wrapper v-if="(!collapsed)">
       <template #default="{ maxFrame, frame, seek }">
         <Timeline
@@ -131,10 +145,4 @@ export default defineComponent({
 </template>
 
 <style scoped>
-.timeline-buttons{
-  position:relative;
-  top:-24px;
-  margin-bottom:-24px;
-  width: 250px;
-}
 </style>

--- a/client/src/views/TrackViewer/ControlsContainer.vue
+++ b/client/src/views/TrackViewer/ControlsContainer.vue
@@ -130,5 +130,6 @@ export default defineComponent({
   position:relative;
   top:-24px;
   margin-bottom:-24px;
+  width: 150px;
 }
 </style>


### PR DESCRIPTION
Track Typename fix and some other minor issues I'm trying to tie together into this PR.

Fixes #229 - Added in a watcher to the Type Name for the TrackItem so it can update properly when changed externally
Fixes #203 - Fixed issue where it now scrolls to the proper item.  During the process I noticed that there were issues with the current frame indicator going over the top of the scrollbar and the scrollbar triggering frame changes as well.  I've updated to add a margin around the Detection/Event viewers so that way we can have scroll bars.  This also has the benefit of cleaning up the Numbers for the Detection view.
![image](https://user-images.githubusercontent.com/61746913/89041300-21047100-d313-11ea-97dd-dc3004bf0f05.png)
![image](https://user-images.githubusercontent.com/61746913/89041308-2497f800-d313-11ea-8cb1-a212ab65cec0.png)

Want to add to this:
Fixes #235 - Changed the button into two independent buttons with a toggle.  You can toggle between the two and then if both are off it will hide the timeline view.  Also added to the `Image-Annotator` and `Video-Annotator` that it will resize itself anytime the size of the panel changes.  This makes sure that the image displayed will take up the full area.
![image](https://user-images.githubusercontent.com/61746913/89041503-7b053680-d313-11ea-8a1d-92bb1d99dfe8.png)
![image](https://user-images.githubusercontent.com/61746913/89041539-8c4e4300-d313-11ea-81c0-381830a283f0.png)
