### PR TITLE
Change display inside VIAME folder

### DIFF
--- a/client/src/components/RunPipelineMenu.vue
+++ b/client/src/components/RunPipelineMenu.vue
@@ -65,7 +65,7 @@ export default {
 
 <template>
   <v-menu
-    max-width="300"
+    max-width="320"
     offset-y
   >
     <template v-slot:activator="{ on }">
@@ -99,44 +99,46 @@ export default {
           >docs</a>
           for more information about these options.
         </v-card-text>
-        <v-row
-          v-for="(pipeType) in Object.keys(pipelines)"
-          :key="pipeType"
-          class="my-2"
-        >
-          <v-menu
+        <v-row class="px-3">
+          <v-col
+            v-for="(pipeType) in Object.keys(pipelines)"
             :key="pipeType"
-            offset-y
+            cols="6"
           >
-            <template v-slot:activator="{ on }">
-              <v-btn
-                depressed
-                class="mx-2 grow"
-                v-on="on"
-              >
-                {{ pipeTypeDisplay(pipeType) }}
-                <v-icon
-                  left
-                  color="accent"
-                  class="ml-0"
+            <v-menu
+              :key="pipeType"
+              offset-y
+            >
+              <template v-slot:activator="{ on }">
+                <v-btn
+                  depressed
+                  block
+                  v-on="on"
                 >
-                  mdi-menu-down
-                </v-icon>
-              </v-btn>
-            </template>
+                  {{ pipeTypeDisplay(pipeType) }}
+                  <v-icon
+                    left
+                    color="accent"
+                    class="ml-0"
+                  >
+                    mdi-menu-down
+                  </v-icon>
+                </v-btn>
+              </template>
 
-            <v-list>
-              <v-list-item
-                v-for="({ name, pipe }) in pipelines[pipeType].pipes"
-                :key="pipe"
-                @click="runPipelineOnSelectedItem(pipe)"
-              >
-                <v-list-item-title>
-                  {{ name }}
-                </v-list-item-title>
-              </v-list-item>
-            </v-list>
-          </v-menu>
+              <v-list>
+                <v-list-item
+                  v-for="({ name, pipe }) in pipelines[pipeType].pipes"
+                  :key="pipe"
+                  @click="runPipelineOnSelectedItem(pipe)"
+                >
+                  <v-list-item-title>
+                    {{ name }}
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </v-col>
         </v-row>
       </v-card>
     </template>

--- a/client/src/lib/api/viame.service.ts
+++ b/client/src/lib/api/viame.service.ts
@@ -2,7 +2,7 @@ import girderRest from '@/plugins/girder';
 
 interface GirderModel {
   _id: string;
-  _modelType: 'folder' | 'item' | 'file';
+  _modelType: 'folder' | 'item' | 'file' | 'user';
   name: string;
 }
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,7 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { isRootLocation } from '@girder/components/src/utils/locationHelpers';
-import { GirderModel } from './lib/api/viame.service';
+
+import { getFolder } from '@/lib/api/girder.service';
+import { GirderModel } from '@/lib/api/viame.service';
 
 interface Location {
   type?: 'collections' | 'users' | 'root';
@@ -12,14 +14,17 @@ interface Location {
 // [x1, y1, x2, y2] as (left, top), (bottom, right)
 export type RectBounds = [number, number, number, number];
 
-function getLocationFromRoute({ params }: { params: GirderModel }) {
+async function getLocationFromRoute({ params }: { params: GirderModel }) {
   if (isRootLocation(params)) {
     return {
       type: params._modelType,
     };
   }
-  if (params._modelType) {
+  if (params._modelType === 'user') {
     return params;
+  }
+  if (params._modelType === 'folder') {
+    return getFolder(params._id);
   }
   return null;
 }

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -45,6 +45,9 @@ export default {
        * by clicking on a Breadcrumb link
        */
       set(value) {
+        if (this.locationIsViameFolder && value.name === 'auxiliary') {
+          return;
+        }
         const newPath = getPathFromLocation(value);
         if (this.$route.path !== newPath) {
           this.$router.push(newPath);


### PR DESCRIPTION
Inside a VIAME folder (marked for annotation) 

* disable selection of rows.
* Show "download" and "run pipeline" buttons, same as if we were in the parent folder and had selected this folder.

This should make it more clear that there's something "special" about this folder.

![Screenshot from 2020-07-31 15-07-34](https://user-images.githubusercontent.com/4214172/89068657-af8ee780-d33f-11ea-803a-df02ab9fc408.png)

fixes #226 