### PR TITLE
Hide button text on breakpoints

### DIFF
--- a/client/src/components/Export.vue
+++ b/client/src/components/Export.vue
@@ -54,14 +54,15 @@ export default {
         :small="small"
         v-on="on"
       >
-        <v-icon
-          left
-          color="accent"
-          class="mdi-24px mr-2"
-        >
+        <v-icon color="accent">
           mdi-export
         </v-icon>
-        Download
+        <span
+          v-show="!$vuetify.breakpoint.mdAndDown"
+          class="pl-1"
+        >
+          Download
+        </span>
       </v-btn>
     </template>
     <template>

--- a/client/src/components/Export.vue
+++ b/client/src/components/Export.vue
@@ -47,23 +47,28 @@ export default {
     offset-y
     max-width="280"
   >
-    <template #activator="{ on }">
-      <v-btn
-        class="ma-0"
-        text
-        :small="small"
-        v-on="on"
-      >
-        <v-icon color="accent">
-          mdi-export
-        </v-icon>
-        <span
-          v-show="!$vuetify.breakpoint.mdAndDown"
-          class="pl-1"
-        >
-          Download
-        </span>
-      </v-btn>
+    <template #activator="{ on: menuOn }">
+      <v-tooltip bottom>
+        <template #activator="{ on: tooltipOn }">
+          <v-btn
+            class="ma-0"
+            text
+            :small="small"
+            v-on="{ ...tooltipOn, ...menuOn }"
+          >
+            <v-icon color="accent">
+              mdi-download
+            </v-icon>
+            <span
+              v-show="!$vuetify.breakpoint.mdAndDown"
+              class="pl-1"
+            >
+              Download
+            </span>
+          </v-btn>
+        </template>
+        <span>Download media and annotations</span>
+      </v-tooltip>
     </template>
     <template>
       <v-card v-if="menuOpen && exportUrls">
@@ -88,22 +93,24 @@ export default {
 
         <v-card-text class="pb-0">
           <div>Get latest detections csv only</div>
-          <v-checkbox
-            v-model="excludeFiltered"
-            label="exclude tracks below confidence threshold"
-            dense
-            hide-details
-          />
-          <div class="py-2">
-            <span>Current thresholds:</span>
-            <span
-              v-for="(val, key) in exportUrls.currentThresholds"
-              :key="key"
-              class="pt-2"
-            >
-              ({{ key }}, {{ val }})
-            </span>
-          </div>
+          <template v-if="Object.keys(exportUrls.currentThresholds).length">
+            <v-checkbox
+              v-model="excludeFiltered"
+              label="exclude tracks below confidence threshold"
+              dense
+              hide-details
+            />
+            <div class="py-2">
+              <span>Current thresholds:</span>
+              <span
+                v-for="(val, key) in exportUrls.currentThresholds"
+                :key="key"
+                class="pt-2"
+              >
+                ({{ key }}, {{ val }})
+              </span>
+            </div>
+          </template>
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/client/src/components/RunPipelineMenu.vue
+++ b/client/src/components/RunPipelineMenu.vue
@@ -68,23 +68,28 @@ export default {
     max-width="300"
     offset-y
   >
-    <template v-slot:activator="{ on }">
-      <v-btn
-        text
-        :small="small"
-        :disabled="pipelinesNotRunnable"
-        v-on="on"
-      >
-        <v-icon color="accent">
-          mdi-pipe
-        </v-icon>
-        <span
-          v-show="!$vuetify.breakpoint.mdAndDown"
-          class="pl-1"
-        >
-          Run pipeline
-        </span>
-      </v-btn>
+    <template v-slot:activator="{ on: menuOn }">
+      <v-tooltip bottom>
+        <template #activator="{ on: tooltipOn }">
+          <v-btn
+            text
+            :small="small"
+            :disabled="pipelinesNotRunnable"
+            v-on="{ ...tooltipOn, ...menuOn }"
+          >
+            <v-icon color="accent">
+              mdi-pipe
+            </v-icon>
+            <span
+              v-show="!$vuetify.breakpoint.mdAndDown"
+              class="pl-1"
+            >
+              Run pipeline
+            </span>
+          </v-btn>
+        </template>
+        <span>Run CV algorithm pipelines on this data</span>
+      </v-tooltip>
     </template>
 
     <template>

--- a/client/src/components/RunPipelineMenu.vue
+++ b/client/src/components/RunPipelineMenu.vue
@@ -75,13 +75,15 @@ export default {
         :disabled="pipelinesNotRunnable"
         v-on="on"
       >
-        <v-icon
-          left
-          color="accent"
-        >
+        <v-icon color="accent">
           mdi-pipe
         </v-icon>
-        Run pipeline
+        <span
+          v-show="!$vuetify.breakpoint.mdAndDown"
+          class="pl-1"
+        >
+          Run pipeline
+        </span>
       </v-btn>
     </template>
 

--- a/client/src/components/UserGuideButton.vue
+++ b/client/src/components/UserGuideButton.vue
@@ -30,10 +30,10 @@ export default {
       color="secondary darken-2"
       class="mx-3"
     >
-      User Guide
-      <v-icon class="pl-2">
+      <v-icon left>
         mdi-help-circle
       </v-icon>
+      User Guide
     </v-btn>
     <v-dialog
       v-else
@@ -49,10 +49,15 @@ export default {
           class="mx-3"
           v-on="on"
         >
-          Help
-          <v-icon class="pl-2">
+          <v-icon>
             mdi-help-circle
           </v-icon>
+          <span
+            v-show="!$vuetify.breakpoint.smAndDown"
+            class="pl-1"
+          >
+            Help
+          </span>
         </v-btn>
       </template>
       <v-card>

--- a/client/src/components/UserGuideButton.vue
+++ b/client/src/components/UserGuideButton.vue
@@ -53,7 +53,7 @@ export default {
             mdi-help-circle
           </v-icon>
           <span
-            v-show="!$vuetify.breakpoint.smAndDown"
+            v-show="!$vuetify.breakpoint.mdAndDown"
             class="pl-1"
           >
             Help


### PR DESCRIPTION
![Screenshot from 2020-08-05 13-27-11](https://user-images.githubusercontent.com/4214172/89444231-64018280-d71f-11ea-9cba-f197cc46ff50.png)

Remove button text in toolbar on page breakpoints to make room for the stuff we've added to the toolbar.

Below a certain width, this app becomes useless, so I'm not going to agonize over proper scaling at mobile widths.