### PR TITLE
Cleaning up the selection and deselection of handle indices

### DIFF
--- a/client/src/components/layers/EditAnnotationLayer.ts
+++ b/client/src/components/layers/EditAnnotationLayer.ts
@@ -126,6 +126,11 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
     if (this.featureLayer) {
       this.featureLayer.removeAllAnnotations();
       this.featureLayer.mode(null);
+      if (this.selectedHandleIndex !== -1) {
+        this.selectedHandleIndex = -1;
+        this.hoverHandleIndex = -1;
+        this.$emit('update:selectedIndex', this.selectedHandleIndex);
+      }
     }
   }
 
@@ -150,6 +155,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
   formatData(frameData: FrameDataTrack[]) {
     this.selectedHandleIndex = -1;
     this.hoverHandleIndex = -1;
+    this.$emit('update:selectedIndex', this.selectedHandleIndex);
     if (frameData.length > 0) {
       const track = frameData[0];
       if (track.features && track.features.bounds) {

--- a/client/src/use/useModeManager.ts
+++ b/client/src/use/useModeManager.ts
@@ -84,7 +84,6 @@ export default function useModeManager({
     if (newTrackMode && !edit) {
       newTrackMode = false;
     }
-    handleSelectFeatureHandle(-1);
   }
 
   function handleAddTrack() {
@@ -237,7 +236,6 @@ export default function useModeManager({
   }) {
     if (visible) annotationModes.state.visible = visible;
     if (editing) annotationModes.state.editing = editing;
-    handleSelectFeatureHandle(-1);
   }
 
   return {


### PR DESCRIPTION
This solves the issue of selecting a point and then advancing a frame and still having the "Delete Point" button visible. 
Totally up to you if you want to to accept or go with the other way.  I wasn't thinking properly before and forgot about the disable method available to the `EditAnnotationLayer` and that we can use that as well as the change data to recognize when it changes modes.  I understand if you feel it's clearer to keep the reselection to -1 in the modeManager, but if we do we would need to add a watcher to  the current `frame` to handle when that changes as well.  This should make it so that the Layer is always synced with the property.