### PR TITLE
Make polygon attribute optional

### DIFF
--- a/server/viame_server/serializers/models.py
+++ b/server/viame_server/serializers/models.py
@@ -8,7 +8,7 @@ class Feature:
 
     frame: int
     bounds: List[float]
-    polygon: List[float]
+    polygon: Optional[List[float]] = None
     head: Optional[Tuple[float, float]] = None
     tail: Optional[Tuple[float, float]] = None
     fishLength: Optional[float] = None


### PR DESCRIPTION
Was getting errors when testing out other files types that didn't contain polygons.  I believe this is the fix to the issue I was seeing.
