### PR TITLE
WIP - Layer Splitting

### DIFF
--- a/client/src/components/layers/AnnotationLayers/LineLayer.ts
+++ b/client/src/components/layers/AnnotationLayers/LineLayer.ts
@@ -1,0 +1,129 @@
+/* eslint-disable class-methods-use-this */
+import BaseLayer, { LayerStyle, BaseLayerParams } from '@/components/layers/BaseLayer';
+import { FrameDataTrack } from '@/components/layers/LayerTypes';
+
+interface LineGeoJSData{
+  trackId: number;
+  selected: boolean;
+  editing: boolean | string;
+  confidencePairs: [string, number] | null;
+  line: GeoJSON.LineString;
+}
+
+
+export default class LineLayer extends BaseLayer<LineGeoJSData> {
+  constructor(params: BaseLayerParams) {
+    super(params);
+    //Only initialize once, prevents recreating Layer each edit
+    this.initialize();
+  }
+
+  initialize() {
+    const layer = this.annotator.geoViewer.createLayer('feature', {
+      features: ['point', 'line'],
+    });
+    this.featureLayer = layer
+      .createFeature('line', { selectionAPI: true });
+    super.initialize();
+  }
+
+  formatData(frameData: FrameDataTrack[]) {
+    const arr: LineGeoJSData[] = [];
+    frameData.forEach((track: FrameDataTrack) => {
+      if (track.features && track.features.bounds) {
+        if (track.features.geometry?.features?.[0]) {
+          track.features.geometry.features.forEach((feature) => {
+            if (feature.geometry && feature.geometry.type === 'LineString') {
+              const line = feature.geometry;
+              const annotation: LineGeoJSData = {
+                trackId: track.trackId,
+                selected: track.selected,
+                editing: track.editing,
+                confidencePairs: track.confidencePairs,
+                line,
+              };
+              arr.push(annotation);
+            }
+          });
+        }
+      }
+    });
+    return arr;
+  }
+
+  redraw() {
+    this.featureLayer
+      .data(this.formattedData)
+      .line((d: LineGeoJSData) => d.line.coordinates[0])
+      .draw();
+  }
+
+  disable() {
+    this.featureLayer
+      .data([])
+      .draw();
+  }
+
+  createStyle(): LayerStyle<LineGeoJSData> {
+    return {
+      ...super.createStyle(),
+      // Style conversion to get array objects to work in geoJS
+      position: (point) => ({ x: point[0], y: point[1] }),
+      strokeColor: (_point, _index, data) => {
+        if (data.selected) {
+          return this.stateStyling.selected.color;
+        }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.color(data.confidencePairs[0]);
+        }
+        return this.typeStyling.value.color('');
+      },
+      fill: (data) => {
+        if (data.confidencePairs) {
+          return this.typeStyling.value.fill(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.fill;
+      },
+      fillColor: (_point, _index, data) => {
+        if (data.confidencePairs) {
+          return this.typeStyling.value.color(data.confidencePairs[0]);
+        }
+        return this.typeStyling.value.color('');
+      },
+      fillOpacity: (_point, _index, data) => {
+        if (data.confidencePairs) {
+          return this.typeStyling.value.opacity(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.opacity;
+      },
+      strokeOpacity: (_point, _index, data) => {
+        if (data.selected) {
+          return this.stateStyling.selected.opacity;
+        }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.opacity(data.confidencePairs[0]);
+        }
+
+        return this.stateStyling.standard.opacity;
+      },
+      strokeOffset: (_point, _index, data) => {
+        if (data.selected) {
+          return this.stateStyling.selected.strokeWidth;
+        }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.strokeWidth;
+      },
+      strokeWidth: (_point, _index, data) => {
+        if (data.selected) {
+          return this.stateStyling.selected.strokeWidth;
+        }
+        if (data.confidencePairs) {
+          return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+        }
+        return this.stateStyling.standard.strokeWidth;
+      },
+    };
+  }
+}

--- a/client/src/components/layers/AnnotationLayers/PointLayer.ts
+++ b/client/src/components/layers/AnnotationLayers/PointLayer.ts
@@ -1,0 +1,104 @@
+import BaseLayer, { LayerStyle } from '../BaseLayer';
+import { FrameDataTrack } from '../LayerTypes';
+
+interface PointGeoJSData {
+    trackId: number;
+    selected: boolean;
+    editing: boolean | string;
+    confidencePairs: [string, number] | null;
+    feature: string;
+    x: number;
+    y: number;
+}
+
+export default class PointLayer extends BaseLayer<PointGeoJSData> {
+  initialize() {
+    const layer = this.annotator.geoViewer.createLayer('feature', {
+      features: ['point'],
+    });
+    this.featureLayer = layer.createFeature('point');
+    super.initialize();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  checkHeadTail(frameData: FrameDataTrack[]): PointGeoJSData[] {
+    const data = [] as PointGeoJSData[];
+    frameData.forEach((track: FrameDataTrack) => {
+      const feature = track.features;
+      if (feature?.head) {
+        data.push({
+          trackId: track.trackId,
+          selected: track.selected,
+          editing: track.editing,
+          confidencePairs: track.confidencePairs,
+          feature: 'head',
+          x: feature.head[0],
+          y: feature.head[1],
+        });
+      }
+      if (feature?.tail) {
+        data.push({
+          trackId: track.trackId,
+          selected: track.selected,
+          editing: track.editing,
+          confidencePairs: track.confidencePairs,
+          feature: 'tail',
+          x: feature.tail[0],
+          y: feature.tail[1],
+        });
+      }
+    });
+    return data;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  formatData(frameData: FrameDataTrack[]): PointGeoJSData[] {
+    const arr: PointGeoJSData[] = [];
+    arr.concat(this.checkHeadTail(frameData));
+    frameData.forEach((track: FrameDataTrack) => {
+      if (track.features && track.features.bounds) {
+        if (track.features.geometry?.features?.[0]) {
+          track.features.geometry.features.forEach((feature) => {
+            if (feature.geometry && feature.geometry.type === 'Point') {
+              const [x, y] = feature.geometry.coordinates;
+              let key = 'point';
+              if (feature.properties && feature.properties.key) {
+                key = feature.properties.key;
+              }
+              const annotation: PointGeoJSData = {
+                trackId: track.trackId,
+                selected: track.selected,
+                editing: track.editing,
+                confidencePairs: track.confidencePairs,
+                feature: key,
+                x,
+                y,
+              };
+              arr.push(annotation);
+            }
+          });
+        }
+      }
+    });
+    return arr;
+  }
+
+  createStyle(): LayerStyle<PointGeoJSData> {
+    return {
+      ...super.createStyle(),
+      fill: true,
+      fillColor: (data: PointGeoJSData) => (data.feature === 'tail' ? 'orange' : 'blue'),
+      radius: 4,
+    };
+  }
+
+  redraw(): null {
+    return this.featureLayer.data(this.formattedData).draw();
+  }
+
+  disable() {
+    this.featureLayer
+      .data([])
+      .draw();
+  }
+}

--- a/client/src/components/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/components/layers/AnnotationLayers/PolygonLayer.ts
@@ -1,0 +1,168 @@
+/* eslint-disable class-methods-use-this */
+import BaseLayer, { LayerStyle, BaseLayerParams } from '@/components/layers/BaseLayer';
+import geo, { GeoEvent } from 'geojs';
+import { FrameDataTrack } from '@/components/layers/LayerTypes';
+
+interface PolyGeoJSData{
+  trackId: number;
+  selected: boolean;
+  editing: boolean | string;
+  confidencePairs: [string, number] | null;
+  polygon: GeoJSON.Polygon;
+}
+
+
+export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
+    drawingOther: boolean; //drawing another type of annotation at the same time?
+
+    constructor(params: BaseLayerParams) {
+      super(params);
+      this.drawingOther = false;
+      //Only initialize once, prevents recreating Layer each edit
+      this.initialize();
+    }
+
+    initialize() {
+      const layer = this.annotator.geoViewer.createLayer('feature', {
+        features: ['polygon'],
+      });
+      this.featureLayer = layer
+        .createFeature('polygon', { selectionAPI: true })
+        .geoOn(geo.event.feature.mouseclick, (e: GeoEvent) => {
+        /**
+         * Handle clicking on individual annotations, if DrawingOther is true we use the
+         * Rectangle type if only the polygon is visible we use the polygon bounds
+         * */
+          if (e.mouse.buttonsDown.left && !this.drawingOther) {
+            if (!e.data.editing || (e.data.editing && !e.data.selected)) {
+              this.$emit('annotationClicked', e.data.trackId, false);
+            }
+          } else if (e.mouse.buttonsDown.right && !this.drawingOther) {
+            if (!e.data.editing || (e.data.editing && !e.data.selected)) {
+              this.$emit('annotationRightClicked', e.data.trackId, true);
+            }
+          }
+        });
+      this.featureLayer.geoOn(
+        geo.event.feature.mouseclick_order,
+        this.featureLayer.mouseOverOrderClosestBorder,
+      );
+      this.featureLayer.geoOn(geo.event.mouseclick, (e: GeoEvent) => {
+      // If we aren't clicking on an annotation we can deselect the current track
+        if (this.featureLayer.pointSearch(e.geo).found.length === 0 && !this.drawingOther) {
+          this.$emit('annotationClicked', null, false);
+        }
+      });
+      super.initialize();
+    }
+
+    /**
+   * Used to set the drawingOther parameter used to change styling if other types are drawn
+   * and also handle selection clicking between different types
+   * @param val - determines if we are drawing other types of annotations
+   */
+    setDrawingOther(val: boolean) {
+      this.drawingOther = val;
+    }
+
+
+    formatData(frameData: FrameDataTrack[]) {
+      const arr: PolyGeoJSData[] = [];
+      frameData.forEach((track: FrameDataTrack) => {
+        if (track.features && track.features.bounds) {
+          if (track.features.geometry?.features?.[0]) {
+            track.features.geometry.features.forEach((feature) => {
+              if (feature.geometry && feature.geometry.type === 'Polygon') {
+                const polygon = feature.geometry;
+                const annotation: PolyGeoJSData = {
+                  trackId: track.trackId,
+                  selected: track.selected,
+                  editing: track.editing,
+                  confidencePairs: track.confidencePairs,
+                  polygon,
+                };
+                arr.push(annotation);
+              }
+            });
+          }
+        }
+      });
+      return arr;
+    }
+
+    redraw() {
+      this.featureLayer
+        .data(this.formattedData)
+        .polygon((d: PolyGeoJSData) => d.polygon.coordinates[0])
+        .draw();
+    }
+
+    disable() {
+      this.featureLayer
+        .data([])
+        .draw();
+    }
+
+    createStyle(): LayerStyle<PolyGeoJSData> {
+      return {
+        ...super.createStyle(),
+        // Style conversion to get array objects to work in geoJS
+        position: (point) => ({ x: point[0], y: point[1] }),
+        strokeColor: (_point, _index, data) => {
+          if (data.selected) {
+            return this.stateStyling.selected.color;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.color(data.confidencePairs[0]);
+          }
+          return this.typeStyling.value.color('');
+        },
+        fill: (data) => {
+          if (data.confidencePairs) {
+            return this.typeStyling.value.fill(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.fill;
+        },
+        fillColor: (_point, _index, data) => {
+          if (data.confidencePairs) {
+            return this.typeStyling.value.color(data.confidencePairs[0]);
+          }
+          return this.typeStyling.value.color('');
+        },
+        fillOpacity: (_point, _index, data) => {
+          if (data.confidencePairs) {
+            return this.typeStyling.value.opacity(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.opacity;
+        },
+        strokeOpacity: (_point, _index, data) => {
+          if (data.selected) {
+            return this.stateStyling.selected.opacity;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.opacity(data.confidencePairs[0]);
+          }
+
+          return this.stateStyling.standard.opacity;
+        },
+        strokeOffset: (_point, _index, data) => {
+          if (data.selected) {
+            return this.stateStyling.selected.strokeWidth;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.strokeWidth;
+        },
+        strokeWidth: (_point, _index, data) => {
+          if (data.selected) {
+            return this.stateStyling.selected.strokeWidth;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.strokeWidth;
+        },
+      };
+    }
+}

--- a/client/src/components/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/components/layers/AnnotationLayers/RectangleLayer.ts
@@ -1,0 +1,178 @@
+/* eslint-disable class-methods-use-this */
+import BaseLayer, { LayerStyle, BaseLayerParams } from '@/components/layers/BaseLayer';
+import { boundToGeojson } from '@/utils';
+import geo, { GeoEvent } from 'geojs';
+import { FrameDataTrack } from '@/components/layers/LayerTypes';
+
+interface RectGeoJSData{
+  trackId: number;
+  selected: boolean;
+  editing: boolean | string;
+  confidencePairs: [string, number] | null;
+  polygon: GeoJSON.Polygon;
+  hasPoly: boolean;
+}
+
+
+export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
+    drawingOther: boolean; //drawing another type of annotation at the same time?
+
+    constructor(params: BaseLayerParams) {
+      super(params);
+      this.drawingOther = false;
+      //Only initialize once, prevents recreating Layer each edit
+      this.initialize();
+    }
+
+    initialize() {
+      const layer = this.annotator.geoViewer.createLayer('feature', {
+        features: ['polygon'],
+      });
+      this.featureLayer = layer
+        .createFeature('polygon', { selectionAPI: true })
+        .geoOn(geo.event.feature.mouseclick, (e: GeoEvent) => {
+        /**
+         * Handle clicking on individual annotations, if DrawingOther is true we use the
+         * Rectangle type if only the polygon is visible we use the polygon bounds
+         * */
+          if (e.mouse.buttonsDown.left) {
+            if (!e.data.editing || (e.data.editing && !e.data.selected)) {
+              this.$emit('annotationClicked', e.data.trackId, false);
+            }
+          } else if (e.mouse.buttonsDown.right) {
+            if (!e.data.editing || (e.data.editing && !e.data.selected)) {
+              this.$emit('annotationRightClicked', e.data.trackId, true);
+            }
+          }
+        });
+      this.featureLayer.geoOn(
+        geo.event.feature.mouseclick_order,
+        this.featureLayer.mouseOverOrderClosestBorder,
+      );
+      this.featureLayer.geoOn(geo.event.mouseclick, (e: GeoEvent) => {
+      // If we aren't clicking on an annotation we can deselect the current track
+        if (this.featureLayer.pointSearch(e.geo).found.length === 0) {
+          this.$emit('annotationClicked', null, false);
+        }
+      });
+      super.initialize();
+    }
+
+    /**
+   * Used to set the drawingOther parameter used to change styling if other types are drawn
+   * and also handle selection clicking between different types
+   * @param val - determines if we are drawing other types of annotations
+   */
+    setDrawingOther(val: boolean) {
+      this.drawingOther = val;
+    }
+
+
+    formatData(frameData: FrameDataTrack[]) {
+      const arr: RectGeoJSData[] = [];
+      frameData.forEach((track: FrameDataTrack) => {
+        if (track.features && track.features.bounds) {
+          const polygon = boundToGeojson(track.features.bounds);
+          let hasPoly = false;
+          if (track.features.geometry?.features) {
+            const filtered = track.features.geometry.features.filter((feature) => feature.geometry && feature.geometry.type === 'Polygon');
+            hasPoly = filtered.length > 0;
+          }
+          const annotation: RectGeoJSData = {
+            trackId: track.trackId,
+            selected: track.selected,
+            editing: track.editing,
+            confidencePairs: track.confidencePairs,
+            polygon,
+            hasPoly,
+          };
+          arr.push(annotation);
+        }
+      });
+      return arr;
+    }
+
+    redraw() {
+      this.featureLayer
+        .data(this.formattedData)
+        .polygon((d: RectGeoJSData) => d.polygon.coordinates[0])
+        .draw();
+    }
+
+    disable() {
+      this.featureLayer
+        .data([])
+        .draw();
+    }
+
+    createStyle(): LayerStyle<RectGeoJSData> {
+      return {
+        ...super.createStyle(),
+        // Style conversion to get array objects to work in geoJS
+        position: (point) => ({ x: point[0], y: point[1] }),
+        strokeColor: (_point, _index, data) => {
+          if (data.selected) {
+            return this.stateStyling.selected.color;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.color(data.confidencePairs[0]);
+          }
+          return this.typeStyling.value.color('');
+        },
+        fill: (data) => {
+          if (data.confidencePairs) {
+            return this.typeStyling.value.fill(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.fill;
+        },
+        fillColor: (_point, _index, data) => {
+          if (data.confidencePairs) {
+            return this.typeStyling.value.color(data.confidencePairs[0]);
+          }
+          return this.typeStyling.value.color('');
+        },
+        fillOpacity: (_point, _index, data) => {
+          if (data.confidencePairs) {
+            return this.typeStyling.value.opacity(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.opacity;
+        },
+        strokeOpacity: (_point, _index, data) => {
+        // Reduce the rectangle opacity if a polygon is also drawn
+          if (this.drawingOther && data.hasPoly) {
+            return this.stateStyling.disabled.opacity;
+          }
+          if (data.selected) {
+            return this.stateStyling.selected.opacity;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.opacity(data.confidencePairs[0]);
+          }
+
+          return this.stateStyling.standard.opacity;
+        },
+        strokeOffset: (_point, _index, data) => {
+          if (data.selected) {
+            return this.stateStyling.selected.strokeWidth;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.strokeWidth;
+        },
+        strokeWidth: (_point, _index, data) => {
+        //Reduce rectangle line thickness if polygon is also drawn
+          if (this.drawingOther && data.hasPoly) {
+            return this.stateStyling.disabled.strokeWidth;
+          }
+          if (data.selected) {
+            return this.stateStyling.selected.strokeWidth;
+          }
+          if (data.confidencePairs) {
+            return this.typeStyling.value.strokeWidth(data.confidencePairs[0]);
+          }
+          return this.stateStyling.standard.strokeWidth;
+        },
+      };
+    }
+}

--- a/client/src/components/layers/EditAnnotationLayer.ts
+++ b/client/src/components/layers/EditAnnotationLayer.ts
@@ -159,7 +159,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
     if (frameData.length > 0) {
       const track = frameData[0];
       if (track.features && track.features.bounds) {
-        let geoJSONData: GeoJSON.Point | GeoJSON.Polygon | undefined;
+        let geoJSONData: GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString | undefined;
         if (this.type === 'rectangle') {
           geoJSONData = boundToGeojson(track.features.bounds);
         } else if (this.type === 'polygon') {

--- a/client/src/lib/track.ts
+++ b/client/src/lib/track.ts
@@ -10,7 +10,7 @@ import {
 
 export type ConfidencePair = [string, number];
 export type TrackId = number;
-export type TrackSupportedFeature = GeoJSON.Point | GeoJSON.Polygon;
+export type TrackSupportedFeature = GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString;
 export interface StringKeyObject {
   [key: string]: unknown;
 }

--- a/client/src/views/TrackViewer/Layers.vue
+++ b/client/src/views/TrackViewer/Layers.vue
@@ -14,6 +14,8 @@ import Track, { TrackId } from '@/lib/track';
 import IntervalTree from '@flatten-js/interval-tree';
 
 import AnnotationLayer from '@/components/layers/AnnotationLayer';
+import RectangleLayer from '@/components/layers/AnnotationLayers/RectangleLayer';
+import PolygonLayer from '@/components/layers/AnnotationLayers/PolygonLayer';
 import { Annotator } from '@/components/annotators/annotatorType';
 import TextLayer from '@/components/layers/TextLayer';
 import EditAnnotationLayer, { EditAnnotationTypes } from '@/components/layers/EditAnnotationLayer';
@@ -71,17 +73,15 @@ export default defineComponent({
     const annotator = inject('annotator') as Annotator;
     const frameNumber: Readonly<Ref<number>> = computed(() => annotator.frame as number);
 
-    const rectAnnotationLayer = new AnnotationLayer({
+    const rectAnnotationLayer = new RectangleLayer({
       annotator,
       stateStyling: props.stateStyling,
       typeStyling: props.typeStyling,
-      type: 'rectangle',
     });
-    const polyAnnotationLayer = new AnnotationLayer({
+    const polyAnnotationLayer = new PolygonLayer({
       annotator,
       stateStyling: props.stateStyling,
       typeStyling: props.typeStyling,
-      type: 'polygon',
     });
 
     const textLayer = new TextLayer({
@@ -237,7 +237,7 @@ export default defineComponent({
 
 
     const Clicked = (trackId: number, editing: boolean) => {
-      //So we only want to pass the click whjen not in creation mode or editing mode for features
+      //So we only want to pass the click when not in creation mode or editing mode for features
       const creationMode = editAnnotationLayer.getMode() === 'creation';
       const editingPolyorLine = (editingType.value && (editingType.value === 'polygon' || editingType.value === 'line'));
       if (!props.featurePointing.value && !(editingPolyorLine && creationMode)) {


### PR DESCRIPTION
Idea is to get layers split into separate classes to make it easier to modify their rendering and customize the styles.

Progress:
Initial pass of splitting up the AnnotationLayer into RectangleLayer, PolygonLayer, LineLayer, and PointLayer.

PointLayer is kind of special because it looks in the standard `feature.geometry` array for points as well as having a separate function for the head/tails that are used.

One of the key goals of this is to get the head/tail creation and display to be a line.  So created using a line annotation as well as displayed as a line from head to tail.  The way stuff is rendered right now and not wanting to change the data format immediately I'll get it to work in the new layer system and we can then go from there.

One of the side thing of the LineLayer is I might include within it a geoJS Point layer so that it can display points of the line if the configuration (probably in `geometry.properties`) specifies drawing the points it will do that right in the `LineLayer`.

Tasking Left to do:

- [ ] Creation of lines within the EditAnnotationLayer and updating the feature data
- [ ] Line creation limiting by number of points.  Head/Tails is a line limited to two points
- [ ] UI mouse interface, I think mose people will assume it works like the rect creation where you hold down the mouse and drag to create to the two points.  I'm not sure if geoJS currently supports that type of line creation, I know it is like that for rects but probably not for lines
- [ ] Refactoring Annotation SubLayers to have an inherited base layer to remove duplicate code.
