### PR TITLE
Fix deployment and ensure uptime

### DIFF
--- a/docker/ansible/.vars.example.yml
+++ b/docker/ansible/.vars.example.yml
@@ -1,4 +1,4 @@
 ---
 deploy_email_address: address.to.send.from@gmail.com
 notify_email_address: address.to.send.to@gmail.com
-
+project_directory: /home/viame

--- a/docker/ansible/README.md
+++ b/docker/ansible/README.md
@@ -30,3 +30,6 @@ Once the service is initiated, it will run the `deploy.yml` playbook at the inte
 
 - `deploy_email_address` - The email address that the emails will be sent from
 - `notify_email_address` - The email address that the emails will be sent to
+- `project_directory` - The directory on the local machine that the project is located
+
+**Note**: The `project_directory` variable is used as a convienience for developers, but the `viame-deploy.service` file still contains a hardcoded reference to `home/viame`. If trying to use the service/timer in a local setup under a different directory, you will need to edit the `viame-deploy.service` file by hand.

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -46,6 +46,13 @@
         project_src: "{{ project_directory }}/docker"
         state: absent
 
+      # Necessary so that the old pipelines data doesn't overwrite any changes
+    - name: Remove pipelines volume
+      when: not build.failed and build.changed
+      docker_volume:
+        name: viame_web_pipelines
+        state: absent
+
     - name: Start Service
       docker_compose:
         project_src: "{{ project_directory }}/docker"

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -21,7 +21,7 @@
         state: absent
 
     - name: Send email on build failure
-      when: register.rc != 0
+      when: build.failed
       mail:
         from: "{{ deploy_email_address }}"
         to: "{{ notify_email_address  }}"

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -12,6 +12,12 @@
       args:
         chdir: "{{ project_directory }}"
 
+    - name: Pull Latest Viame Docker Image
+      docker_image:
+        name: kitware/viame:gpu-all-models-latest
+        source: pull
+        force_source: yes
+
     - name: Build Service
       ignore_errors: yes
       register: build

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -10,13 +10,13 @@
     - name: Pull Changes
       shell: git pull
       args:
-        chdir: /home/viame
+        chdir: "{{ project_directory }}"
 
     - name: Build Service
       ignore_errors: yes
       register: build
       docker_compose:
-        project_src: /home/viame/docker
+        project_src: "{{ project_directory }}/docker"
         build: yes
         state: present
 
@@ -35,12 +35,12 @@
           {{ build.module_stderr  }}
 
     - name: Stop Service
-      when: not build.failed
+      when: not build.failed and build.changed
       docker_compose:
-        project_src: /home/viame
+        project_src: "{{ project_directory }}/docker"
         state: absent
 
     - name: Start Service
       docker_compose:
-        project_src: /home/viame
-        state: absent
+        project_src: "{{ project_directory }}/docker"
+        state: present

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -12,12 +12,7 @@
       args:
         chdir: /home/viame
 
-    - name: Stop Service
-      docker_compose:
-        project_src: /home/viame
-        state: absent
-    
-    - name: Build and Start Service
+    - name: Build Service
       ignore_errors: yes
       register: build
       docker_compose:
@@ -39,8 +34,13 @@
           Captured stderr:
           {{ build.module_stderr  }}
 
-    - name: Start Service Without Updates
-      when: build.failed
+    - name: Stop Service
+      when: not build.failed
       docker_compose:
-        project_src: /home/viame/docker
-        state: present
+        project_src: /home/viame
+        state: absent
+
+    - name: Start Service
+      docker_compose:
+        project_src: /home/viame
+        state: absent

--- a/docker/ansible/deploy.yml
+++ b/docker/ansible/deploy.yml
@@ -7,20 +7,26 @@
   vars_files:
       - ".vars.yml"
   tasks:
-    - name: Pull Repository Changes
+    - name: Pull Changes
       shell: git pull
       args:
         chdir: /home/viame
 
-    - name: Stop and Build Service
+    - name: Stop Service
+      docker_compose:
+        project_src: /home/viame
+        state: absent
+    
+    - name: Build and Start Service
       ignore_errors: yes
       register: build
       docker_compose:
         project_src: /home/viame/docker
         build: yes
-        state: absent
+        state: present
 
     - name: Send email on build failure
+      ignore_errors: yes
       when: build.failed
       mail:
         from: "{{ deploy_email_address }}"
@@ -28,12 +34,13 @@
         subject: Failed Build of Viame-Web
         body: |
           Captured stdout:
-          {{ build.stdout  }}
+          {{ build.module_stdout  }}
 
           Captured stderr:
-          {{ build.stderr  }}
+          {{ build.module_stderr  }}
 
-    - name: Start Service
+    - name: Start Service Without Updates
+      when: build.failed
       docker_compose:
         project_src: /home/viame/docker
         state: present

--- a/docker/girder.Dockerfile
+++ b/docker/girder.Dockerfile
@@ -18,7 +18,13 @@ ENV GIRDER_ADMIN_PASSWORD viame
 ENV CELERY_BROKER_URL amqp://guest:guest@rabbit/
 ENV BROKER_CONNECTION_TIMEOUT 2
 
-COPY --from=builder /app/dist/ /usr/share/girder/static/viame/
+# Initialize python virtual environment
+RUN apt-get update && apt-get install -y python3.7-venv
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.7 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY --from=builder /app/dist/ $VIRTUAL_ENV/share/girder/static/viame/
 
 # install tini init system
 ENV TINI_VERSION v0.19.0

--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -28,6 +28,12 @@ RUN apt-get update && \
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3.7 get-pip.py
 # END port of worker installation
 
+# Initialize python virtual environment
+RUN apt-get update && apt-get install -y python3.7-venv
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.7 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # install tini init system
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini


### PR DESCRIPTION
This PR fixes several things with the deployment:

- Hopefully fixes the girder build issues by using virtual envs (haven't run into the problem testing it myself, but it's sometimes hard to induce)
- Changes the behavior of the deploy script to keep the service up while building, so that downtime is restricted to just the time it takes to restart the docker-compose service (and if there are no changes, there is no downtime)
- Pulls down the latest viame docker image (if there is one) before each build
- Add `project_directory` variable for easier development