### PR TITLE
Streaming Video Fix

### DIFF
--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -46,12 +46,12 @@ class ViameDetection(Resource):
         videoUrl = None
         # Find a video tagged with an h264 codec left by the transcoder
         item = Item().findOne({'folderId': folder['_id'], 'meta.codec': 'h264',})
-        video = Item().childFiles(item)[0]
-        
-        if video:
-            videoUrl = (
-                f'/api/v1/file/{str(video["_id"])}/download?contentDisposition=inline'
-            )
+        if item:
+            video = Item().childFiles(item)[0]
+            if video:
+                videoUrl = (
+                    f'/api/v1/file/{str(video["_id"])}/download?contentDisposition=inline'
+                )
 
         return {
             'folder': folder,

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -48,10 +48,9 @@ class ViameDetection(Resource):
         item = Item().findOne({'folderId': folder['_id'], 'meta.codec': 'h264',})
         if item:
             video = Item().childFiles(item)[0]
-            if video:
-                videoUrl = (
-                    f'/api/v1/file/{str(video["_id"])}/download?contentDisposition=inline'
-                )
+            videoUrl = (
+                f'/api/v1/file/{str(video["_id"])}/download?contentDisposition=inline'
+            )
 
         return {
             'folder': folder,

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -45,10 +45,12 @@ class ViameDetection(Resource):
 
         videoUrl = None
         # Find a video tagged with an h264 codec left by the transcoder
-        video = Item().findOne({'folderId': folder['_id'], 'meta.codec': 'h264',})
+        item = Item().findOne({'folderId': folder['_id'], 'meta.codec': 'h264',})
+        video = Item().childFiles(item)[0]
+        
         if video:
             videoUrl = (
-                f'/api/v1/item/{str(video["_id"])}/download?contentDisposition=inline'
+                f'/api/v1/file/{str(video["_id"])}/download?contentDisposition=inline'
             )
 
         return {


### PR DESCRIPTION
Changes the video file endpoint to the `/file` endpoint.  This endpoint properly supports streaming of files using the correct range headers.  This should fix the issue where it takes an insanely long time to load and playback large videos.  The previous version would try to download the entire file up to that one location in the space.

Let me know if there is a better way or pattern to do this.

Fixes #273 
Fixes the core of what we can reproduce for #171 