### PR TITLE
Add more interesting imagery

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Additional documentation will be available in the future for users.
 <p align="center">
 <br>
 <nobr>
-<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/FishPolygonSelected.png" alt="Example Tracks" width="370" border="1">
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/FishPolygonSelected.png" alt="Example from viame.kitware.com sample data" width="370" border="1">
 &nbsp; &nbsp; &nbsp;
-<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonUAV.png" alt="Example Tracks" width="430" border="1">
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonUAV.png" alt="Example from mevadata.org UAV clip" width="430" border="1">
 &nbsp; &nbsp; &nbsp;
 </nobr>
 </p>

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Additional documentation will be available in the future for users.
 <p align="center">
 <br>
 <nobr>
-<img src="http://www.viametoolkit.org/wp-content/uploads/2019/11/viame-web-prelim.png" alt="Example Tracks" width="405" height="250" border="1">
-&nbsp; &nbsp; &nbsp; 
-<img src="http://www.viametoolkit.org/wp-content/uploads/2019/11/girder-dark-example.png" alt="Dark Girder" width="400" height="250" border="1">
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/FishPolygonSelected.png" alt="Example Tracks" width="400" border="1">
+&nbsp; &nbsp; &nbsp;
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonCar.png" alt="Example Tracks" width="412" border="1">
+&nbsp; &nbsp; &nbsp;
 </nobr>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Additional documentation will be available in the future for users.
 </nobr>
 </p>
 
+## Features
+
+* Video Annotation
+  * Single-frame boxes and polygons
+  * Multi-frame bounding box tracks with interpolation
+  * Automatic transcoding to support `avi`, `mov`, 
+* Still image annotation
+  * Bounding boxes
+  * Polygons
+* Customizable labeling
+  * label shapes and tracks
+  * add text, numeric, multiple-choice attributes
+
 ## Documentation
 
 * [Client User Guide](https://github.com/VIAME/VIAME-Web/wiki)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Additional documentation will be available in the future for users.
 <nobr>
 <img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/FishPolygonSelected.png" alt="Example Tracks" width="400" border="1">
 &nbsp; &nbsp; &nbsp;
-<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonCar.png" alt="Example Tracks" width="412" border="1">
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonUAV.png" alt="Example Tracks" width="400" border="1">
 &nbsp; &nbsp; &nbsp;
 </nobr>
 </p>

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Additional documentation will be available in the future for users.
 <p align="center">
 <br>
 <nobr>
-<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/FishPolygonSelected.png" alt="Example Tracks" width="400" border="1">
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/FishPolygonSelected.png" alt="Example Tracks" width="370" border="1">
 &nbsp; &nbsp; &nbsp;
-<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonUAV.png" alt="Example Tracks" width="400" border="1">
+<img src="https://raw.githubusercontent.com/wiki/VIAME/VIAME-Web/images/Misc/PolygonUAV.png" alt="Example Tracks" width="430" border="1">
 &nbsp; &nbsp; &nbsp;
 </nobr>
 </p>


### PR DESCRIPTION
Intended to be eye-catching and show off a little more of what's been done over the last few months.

Link to diff: https://github.com/VIAME/VIAME-Web/pull/296/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8

I don't want to confuse the messaging about what this tool is, but because these features were developed with general-purpose annotation in mind, it might make sense to showcase that?

In any case, I'd like to show an example of "video" type annotation with bounding boxes and more polygon-type annotation of a single still.