### PR TITLE
Fixes 307

### DIFF
--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -115,11 +115,9 @@ export default defineComponent({
       featurePointing: boolean,
       visibleModes: EditAnnotationTypes[],
     ) {
-      // intervalTree requires custom search because 0 is treated as false by default
-      const currentFrameIds: TrackId[] = props.intervalTree.search(
-        [frame, frame],
-        (value) => (value !== null ? value : null),
-      );
+      const currentFrameIds: TrackId[] = props.intervalTree
+        .search([frame, frame])
+        .map((str: string) => parseInt(str, 10));
 
       if (editingTrack) {
         editAnnotationLayer.setType(editingTrack);

--- a/client/src/use/useTrackStore.spec.ts
+++ b/client/src/use/useTrackStore.spec.ts
@@ -35,7 +35,7 @@ describe('useTrackStore', () => {
 
     ts.removeTrack(t1.trackId);
     expect(Array.from(ts.trackMap.keys()).length).toBe(1);
-    expect(ts.intervalTree.search([0, 0])).toStrictEqual(["0"]);
+    expect(ts.intervalTree.search([0, 0])).toStrictEqual(['0']);
   });
 
   it('marks changes pending when a track updates', () => {

--- a/client/src/use/useTrackStore.spec.ts
+++ b/client/src/use/useTrackStore.spec.ts
@@ -27,6 +27,17 @@ describe('useTrackStore', () => {
     expect(ts.intervalTree.search([10, 20]).length).toBe(0);
   });
 
+  it('can insert and delete single-frame detections', () => {
+    const ts = useTrackStore({ markChangesPending: () => null });
+    const t0 = ts.addTrack(0, 'foo');
+    const t1 = ts.addTrack(0, 'bar');
+    expect(Array.from(ts.trackMap.keys()).length).toBe(2);
+
+    ts.removeTrack(t1.trackId);
+    expect(Array.from(ts.trackMap.keys()).length).toBe(1);
+    expect(ts.intervalTree.search([0, 0])).toStrictEqual(["0"]);
+  });
+
   it('marks changes pending when a track updates', () => {
     let didCall = false;
     const markChangesPending = () => { didCall = true; };

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -58,8 +58,8 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
   ): void {
     if (event === 'bounds') {
       const oldInterval = oldValue as [number, number];
-      intervalTree.remove(oldInterval, track.trackId);
-      intervalTree.insert([track.begin, track.end], track.trackId);
+      intervalTree.remove(oldInterval, track.trackId.toString());
+      intervalTree.insert([track.begin, track.end], track.trackId.toString());
     }
     canary.value += 1;
     markChangesPending('upsert', track);
@@ -68,7 +68,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
   function insertTrack(track: Track) {
     track.bus.$on('notify', onChange);
     trackMap.set(track.trackId, track);
-    intervalTree.insert([track.begin, track.end], track.trackId);
+    intervalTree.insert([track.begin, track.end], track.trackId.toString());
     trackIds.value.push(track.trackId);
   }
 
@@ -89,7 +89,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
     }
     const track = getTrack(trackId);
     const range = [track.begin, track.end];
-    if (!intervalTree.remove(range, trackId)) {
+    if (!intervalTree.remove(range, trackId.toString())) {
       throw new Error(`TrackId ${trackId} with range ${range} not found in tree.`);
     }
     track.bus.$off(); // remove all event listeners


### PR DESCRIPTION
Another consequence of https://github.com/alexbol99/flatten-interval-tree/issues/16

Switch to string keys so we never have falsey keys.

fixes #307 