### PR TITLE
Fix out of bounds error on CSV rows with even number of columns and length >= 10

### DIFF
--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -52,6 +52,46 @@ test_tuple = [
             },
         },
     ),
+    (
+        [
+            # test that variable length is handled properly
+            # length == 11, valid
+            "0,1.png,0,884,510,1219,737,1,-1,typestring,1",
+            # length == 12, note ignored
+            "0,2.png,1,111,222,3333,444,1,-1,typestring,1,(note) note",
+            # Length == 13, both notes ignored
+            "0,3.png,2,747,457,1039,633,1,-1,typestring,1,(note) note,(note) note2",
+        ],
+        {
+            "0": {
+                "trackId": 0,
+                "attributes": {},
+                "confidencePairs": [["typestring", 1.0]],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [884, 510, 1219, 737],
+                        "keyframe": True,
+                        "interpolate": False,
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [111, 222, 3333, 444],
+                        "keyframe": True,
+                        "interpolate": False,
+                    },
+                    {
+                        "frame": 2,
+                        "bounds": [747, 457, 1039, 633],
+                        "keyframe": True,
+                        "interpolate": False,
+                    },
+                ],
+                "begin": 0,
+                "end": 2,
+            },
+        },
+    ),
 ]
 
 

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -54,7 +54,7 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List]:
     confidence_pairs = [
         [row[i], float(row[i + 1])]
         for i in range(9, len(row), 2)
-        if row[i] and row[i + 1] and not row[i].startswith("(")
+        if i + 1 < len(row) and row[i] and row[i + 1] and not row[i].startswith("(")
     ]
     start = len(row) - 1 if len(row) % 2 == 0 else len(row) - 2
 


### PR DESCRIPTION
When trying to import a new dataset, I was running into the following error when loading detections
```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 629, in endpointDecorator
    val = fun(self, path, params)
  File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 1190, in GET
    return self.handleRoute('GET', path, params)
  File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 946, in handleRoute
    val = handler(**kwargs)
  File "/opt/venv/lib/python3.7/site-packages/girder/api/access.py", line 57, in wrapped
    return fun(*args, **kwargs)
  File "/opt/venv/lib/python3.7/site-packages/girder/api/describe.py", line 679, in wrapped
    return fun(*args, **kwargs)
  File "/opt/venv/lib/python3.7/site-packages/viame_server/viame_detection.py", line 257, in get_detection
    return getTrackData(file)
  File "/opt/venv/lib/python3.7/site-packages/viame_server/utils.py", line 103, in getTrackData
    .decode("utf-8")
  File "/opt/venv/lib/python3.7/site-packages/viame_server/serializers/viame.py", line 112, in load_csv_as_tracks
    ) = _parse_row_for_tracks(row)
  File "/opt/venv/lib/python3.7/site-packages/viame_server/serializers/viame.py", line 84, in _parse_row_for_tracks
    head_tail_feature, attributes, track_attributes, confidence_pairs = _parse_row(row)
  File "/opt/venv/lib/python3.7/site-packages/viame_server/serializers/viame.py", line 56, in _parse_row
    for i in range(9, len(row), 2)
  File "/opt/venv/lib/python3.7/site-packages/viame_server/serializers/viame.py", line 57, in <listcomp>
    if row[i] and row[i + 1] and not row[i].startswith("(")
IndexError: list index out of range
```

This is because that csv file had some rows with a column length of 15, and some with a length of 14. So when it got to rows with 14 columns (13 indices), it would eventually check for `row[13]` and `row[14]`, the latter of which causes the error.

You can reproduce this locally by using any existing csv annotation file and adding extra columns to some/all of the rows, such that the number of columns is both even and at least 10. Then, after saving that to girder, trying to load the viewer on this dataset should fail to load annotations, returning an error on the `viame_detection` endpoint.

This PR changes the behavior to check that both indices are valid before accessing the list on that iteration.