### PR TITLE
Rudimentary worker management/limiting

### DIFF
--- a/.env
+++ b/.env
@@ -5,5 +5,8 @@ VIAME_TRAINED_PIPELINES_PATH=/home/worker/trained
 GIRDER_ADMIN_USER=admin
 GIRDER_ADMIN_PASS=letmein
 
+TRAINING_GPU_UUID=
+PIPELINE_GPU_UUID=
+
 # Comment out this line to use default runtime
 WORKER_RUNTIME=nvidia

--- a/.env
+++ b/.env
@@ -5,8 +5,16 @@ VIAME_TRAINED_PIPELINES_PATH=/home/worker/trained
 GIRDER_ADMIN_USER=admin
 GIRDER_ADMIN_PASS=letmein
 
-TRAINING_GPU_UUID=
-PIPELINE_GPU_UUID=
+
+# The GPU to use for the respective container
+# If not specifies, each container will use the first GPU available
+# PIPELINE_GPU_UUID=
+# TRAINING_GPU_UUID=
+
+# How many pipelines can be run at once on the respective container
+# Each defaults to 1 if not supplied here
+# PIPELINE_WORKER_CONCURRENCY=
+# TRAINING_WORKER_CONCURRENCY=
 
 # Comment out this line to use default runtime
 WORKER_RUNTIME=nvidia

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -13,7 +13,11 @@ services:
       - ../server:/home/viame_girder
     entrypoint: ["/home/provision/girder_entrypoint_dev.sh"]
 
-  girder_worker:
+  girder_worker_pipelines:
+    volumes:
+      - ../server:/home/viame_girder
+
+  girder_worker_training:
     volumes:
       - ../server:/home/viame_girder
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,8 @@ services:
     image: kitware/viame-web:${TAG:-latest}
     depends_on:
       - mongo
-      - girder_worker
+      - girder_worker_pipelines
+      - girder_worker_training
     ports:
       - "8010:8080"
     volumes:
@@ -40,7 +41,7 @@ services:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit/
       - BROKER_CONNECTION_TIMEOUT=2
 
-  girder_worker:
+  girder_worker_pipelines:
     runtime: ${WORKER_RUNTIME}
     ipc: host
     build:
@@ -54,6 +55,29 @@ services:
     depends_on:
       - rabbit
     environment:
+      - WORKER_WATCHING_QUEUES=pipelines
+      - WORKER_CONCURRENCY=2
+      - VIAME_PIPELINES_PATH=${VIAME_PIPELINES_PATH}
+      - VIAME_TRAINED_PIPELINES_PATH=${VIAME_TRAINED_PIPELINES_PATH}
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbit/
+      - BROKER_CONNECTION_TIMEOUT=2
+
+  girder_worker_training:
+    runtime: ${WORKER_RUNTIME}
+    ipc: host
+    build:
+      context: ../
+      dockerfile: docker/girder_worker.Dockerfile
+    image: kitware/viame-worker:${TAG:-latest}
+    volumes:
+      # Exposes pipeline directory to girder so it can see what pipelines are available.
+      - pipelines:${VIAME_PIPELINES_PATH}:ro
+      - trained-pipelines:${VIAME_TRAINED_PIPELINES_PATH}
+    depends_on:
+      - rabbit
+    environment:
+      - WORKER_WATCHING_QUEUES=training
+      - WORKER_CONCURRENCY=1
       - VIAME_PIPELINES_PATH=${VIAME_PIPELINES_PATH}
       - VIAME_TRAINED_PIPELINES_PATH=${VIAME_TRAINED_PIPELINES_PATH}
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     << : *base-worker
     environment:
       - WORKER_WATCHING_QUEUES=pipelines
-      - WORKER_CONCURRENCY=2
+      - WORKER_CONCURRENCY=${PIPELINE_WORKER_CONCURRENCY:-1}
       - WORKER_GPU_UUID=${PIPELINE_GPU_UUID}
 
   girder_worker_training:
@@ -75,7 +75,7 @@ services:
     << : *base-worker
     environment:
       - WORKER_WATCHING_QUEUES=training
-      - WORKER_CONCURRENCY=1
+      - WORKER_CONCURRENCY=${TRAINING_WORKER_CONCURRENCY:-1}
       - WORKER_GPU_UUID=${TRAINING_GPU_UUID}
 
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,25 @@
 ## Use this to start the girder/ girder-worker ecosystem
+
+# Use YAML anchors for the common config between both workers
+x-worker: &base-worker
+  runtime: ${WORKER_RUNTIME}
+  ipc: host
+  build:
+    context: ../
+    dockerfile: docker/girder_worker.Dockerfile
+  image: kitware/viame-worker:${TAG:-latest}
+  volumes:
+    # Exposes pipeline directory to girder so it can see what pipelines are available.
+    - pipelines:${VIAME_PIPELINES_PATH}:ro
+    - trained-pipelines:${VIAME_TRAINED_PIPELINES_PATH}
+  depends_on:
+    - rabbit
+  environment:
+    - VIAME_PIPELINES_PATH=${VIAME_PIPELINES_PATH}
+    - VIAME_TRAINED_PIPELINES_PATH=${VIAME_TRAINED_PIPELINES_PATH}
+    - CELERY_BROKER_URL=amqp://guest:guest@rabbit/
+    - BROKER_CONNECTION_TIMEOUT=2
+
 version: "2.4"
 services:
 
@@ -42,46 +63,18 @@ services:
       - BROKER_CONNECTION_TIMEOUT=2
 
   girder_worker_pipelines:
-    runtime: ${WORKER_RUNTIME}
-    ipc: host
-    build:
-      context: ../
-      dockerfile: docker/girder_worker.Dockerfile
-    image: kitware/viame-worker:${TAG:-latest}
-    volumes:
-      # Exposes pipeline directory to girder so it can see what pipelines are available.
-      - pipelines:${VIAME_PIPELINES_PATH}:ro
-      - trained-pipelines:${VIAME_TRAINED_PIPELINES_PATH}
-    depends_on:
-      - rabbit
+    # Merge base-worker object with this config
+    << : *base-worker
     environment:
       - WORKER_WATCHING_QUEUES=pipelines
       - WORKER_CONCURRENCY=2
-      - VIAME_PIPELINES_PATH=${VIAME_PIPELINES_PATH}
-      - VIAME_TRAINED_PIPELINES_PATH=${VIAME_TRAINED_PIPELINES_PATH}
-      - CELERY_BROKER_URL=amqp://guest:guest@rabbit/
-      - BROKER_CONNECTION_TIMEOUT=2
 
   girder_worker_training:
-    runtime: ${WORKER_RUNTIME}
-    ipc: host
-    build:
-      context: ../
-      dockerfile: docker/girder_worker.Dockerfile
-    image: kitware/viame-worker:${TAG:-latest}
-    volumes:
-      # Exposes pipeline directory to girder so it can see what pipelines are available.
-      - pipelines:${VIAME_PIPELINES_PATH}:ro
-      - trained-pipelines:${VIAME_TRAINED_PIPELINES_PATH}
-    depends_on:
-      - rabbit
+    # Merge base-worker object with this config
+    << : *base-worker
     environment:
       - WORKER_WATCHING_QUEUES=training
       - WORKER_CONCURRENCY=1
-      - VIAME_PIPELINES_PATH=${VIAME_PIPELINES_PATH}
-      - VIAME_TRAINED_PIPELINES_PATH=${VIAME_TRAINED_PIPELINES_PATH}
-      - CELERY_BROKER_URL=amqp://guest:guest@rabbit/
-      - BROKER_CONNECTION_TIMEOUT=2
 
 volumes:
   pipelines:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,13 @@ services:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbit/
       - BROKER_CONNECTION_TIMEOUT=2
 
+  # Worker for misc non gpu-bound tasks
+  girder_worker_default:
+    # Merge base-worker object with this config
+    << : *base-worker
+    environment:
+      - WORKER_WATCHING_QUEUES=celery
+
   girder_worker_pipelines:
     # Merge base-worker object with this config
     << : *base-worker

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,7 @@ services:
     environment:
       - WORKER_WATCHING_QUEUES=pipelines
       - WORKER_CONCURRENCY=2
+      - WORKER_GPU_UUID=${PIPELINE_GPU_UUID}
 
   girder_worker_training:
     # Merge base-worker object with this config
@@ -75,6 +76,7 @@ services:
     environment:
       - WORKER_WATCHING_QUEUES=training
       - WORKER_CONCURRENCY=1
+      - WORKER_GPU_UUID=${TRAINING_GPU_UUID}
 
 volumes:
   pipelines:

--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -49,6 +49,9 @@ RUN pip install --no-cache-dir .
 COPY server/ /home/viame_girder/
 RUN pip install --no-deps .
 
+# Copy provision scripts
+COPY docker/provision /home/provision
+
 # Switch over to user "worker"
 RUN useradd -D --shell=/bin/bash && useradd -m worker
 RUN chown -R worker:worker /usr/local/lib/python*
@@ -59,5 +62,5 @@ USER worker
 ENV VIAME_TRAINED_PIPELINES_PATH /home/worker/trained
 RUN mkdir -p ${VIAME_TRAINED_PIPELINES_PATH}
 
-ENTRYPOINT ["/tini", "--", "python3.7", "-m", "girder_worker" ]
-CMD [ "-l", "info" ]
+ENTRYPOINT ["/tini", "--"]
+CMD ["/home/provision/girder_worker_entrypoint.sh"]

--- a/docker/provision/girder_worker_entrypoint.sh
+++ b/docker/provision/girder_worker_entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Environment variables that may be supplied
+# WORKER_CONCURRENCY: The number of concurrent jobs to run at once. If not supplied, the celery default is used.
+# WORKER_WATCHING_QUEUES: The comma separated list of queues to take tasks from. If not supplied, the celery default of 'celery' is used.
+
+QUEUE_ARGUMENT=
+CONCURRENCY_ARGUMENT=
+
+if [ -n "$WORKER_WATCHING_QUEUES" ]; then
+    QUEUE_ARGUMENT="--queues $WORKER_WATCHING_QUEUES"
+fi
+
+if [ -n "$WORKER_CONCURRENCY" ]; then
+    CONCURRENCY_ARGUMENT="--concurrency $WORKER_CONCURRENCY"
+fi
+
+python3.7 -m girder_worker -l info $QUEUE_ARGUMENT $CONCURRENCY_ARGUMENT

--- a/docker/provision/girder_worker_entrypoint.sh
+++ b/docker/provision/girder_worker_entrypoint.sh
@@ -15,4 +15,4 @@ if [ -n "$WORKER_CONCURRENCY" ]; then
     CONCURRENCY_ARGUMENT="--concurrency $WORKER_CONCURRENCY"
 fi
 
-python3.7 -m girder_worker -l info $QUEUE_ARGUMENT $CONCURRENCY_ARGUMENT
+exec python3.7 -m girder_worker -l info $QUEUE_ARGUMENT $CONCURRENCY_ARGUMENT

--- a/server/setup.py
+++ b/server/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "cheroot>=8.4.5", # https://github.com/cherrypy/cheroot/issues/312
+    "cheroot>=8.4.5",  # https://github.com/cherrypy/cheroot/issues/312
     "girder==3.1.0",
     "girder_jobs==3.0.3",
     "girder_worker==0.6.0",
@@ -13,6 +13,7 @@ requirements = [
     "dacite",
     "typing_extensions",
     "diva-boiler",
+    "gputil",
 ]
 
 setup(

--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -249,9 +249,9 @@ class Viame(Resource):
 
             for item in videoItems:
                 convert_video.delay(
-                    GetPathFromItemId(str(item["_id"])),
-                    str(item["folderId"]),
-                    auxiliary["_id"],
+                    path=GetPathFromItemId(str(item["_id"])),
+                    folderId=str(item["folderId"]),
+                    auxiliaryFolderId=auxiliary["_id"],
                     girder_job_title=(
                         "Converting {} to a web friendly format".format(
                             str(item["_id"])
@@ -270,12 +270,13 @@ class Viame(Resource):
 
             if imageItems.count() > safeImageItems.count():
                 convert_images.delay(
-                    folder["_id"],
+                    folderId=folder["_id"],
                     girder_client_token=str(token["_id"]),
                     girder_job_title=(
                         f"Converting {folder['_id']} to a web friendly format",
                     ),
                 )
+
             elif imageItems.count() > 0:
                 folder["meta"]["annotate"] = True
 
@@ -297,7 +298,7 @@ class Viame(Resource):
         csvItems = Folder().childItems(
             folder,
             filters={"lowerName": {"$regex": csvRegex}},
-            sort=[("created", pymongo.DESCENDING,)],
+            sort=[("created", pymongo.DESCENDING)],
         )
         if csvItems.count() >= 1:
             file = Item().childFiles(csvItems.next())[0]
@@ -356,5 +357,5 @@ class Viame(Resource):
         return Folder().childItems(
             folder,
             filters={"lowerName": {"$regex": safeImageRegex}},
-            sort=[("lowerName", pymongo.ASCENDING,)],
+            sort=[("lowerName", pymongo.ASCENDING)],
         )

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -232,9 +232,7 @@ def train_pipeline(
             training_results = training_output_path / trained_model_folder_name
 
             # Rename the original folder with our new folder name
-            shutil.move(
-                str(training_output_path / "category_models"), training_results,
-            )
+            shutil.move(str(training_output_path / "category_models"), training_results)
 
             # If `_trained_pipeline_folder()` returns `None`, the results of this
             # training job will be uploaded to Girder, but will not be runnable as
@@ -302,9 +300,7 @@ def convert_video(self, path, folderId, auxiliaryFolderId):
     output = str(stdout) + "\n" + str(stderr)
     self.job_manager.write(output)
     new_file = self.girder_client.uploadFileToFolder(folderId, output_path)
-    self.girder_client.addMetadataToItem(
-        new_file['itemId'], {"codec": "h264"},
-    )
+    self.girder_client.addMetadataToItem(new_file['itemId'], {"codec": "h264"})
     self.girder_client.addMetadataToFolder(
         folderId,
         {
@@ -348,7 +344,9 @@ def convert_images(self, folderId):
             new_item_path = dest_dir / ".".join([*item["name"].split(".")[:-1], "png"])
 
             process = Popen(
-                ["ffmpeg", "-i", item_path, new_item_path], stdout=PIPE, stderr=PIPE,
+                ["ffmpeg", "-i", item_path, new_item_path],
+                stdout=PIPE,
+                stderr=PIPE,
             )
             stdout, stderr = process.communicate()
 

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -226,12 +226,17 @@ def train_pipeline(
 
             timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
 
-            # Trained_ prefix is added to conform with existing pipeline names
-            trained_model_folder_name = f"trained_{pipeline_name}"
+            # This is the name of the folder that is uploaded to the
+            # "Training Results" girder folder
             girder_output_folder_name = f"{pipeline_name} {timestamp}"
+            girder_output_folder = training_output_path / girder_output_folder_name
+
+            # Trained_ prefix is added to conform with existing pipeline names
+            # This is the name that will appear in the client (with trained_ removed)
+            trained_model_folder_name = f"trained_{pipeline_name}"
             training_results = training_output_path / trained_model_folder_name
 
-            # Rename the original folder with our new folder name
+            # Move the original folder to our new folder
             shutil.move(str(training_output_path / "category_models"), training_results)
 
             # If `_trained_pipeline_folder()` returns `None`, the results of this
@@ -244,9 +249,10 @@ def train_pipeline(
                     trained_pipeline_folder / trained_model_folder_name,
                 )
 
-            training_results.rename(girder_output_folder_name)
+            # Rename this folder so that it appears properly in girder
+            shutil.move(str(training_results), girder_output_folder)
             self.girder_client._uploadFolderRecursive(
-                training_results, results_folder["_id"], "folder"
+                girder_output_folder, results_folder["_id"], "folder"
             )
 
 


### PR DESCRIPTION
Fixes #60.

This is a first pass at a system/configuration for limiting the amount of training/pipeline jobs we're running at once. Notable changes include:

* The `docker-compose.yml` file now uses 3 girder workers instead of just 1.
	* One for running pipelines
    * One for running training
	* One for running miscellaneous tasks (image/video conversion, etc.). Any tasks dispatched with a normal use of `task.delay` will be run by this worker. This worker behaves in the same manner as the original worker, prior to this change.

* `run_pipeline` and `run_training` are now called through `.apply_async` instead of `.delay`. This allows for the specification of which queue it should go to.
* Addition and use of `girder_worker_entrypoint.sh`
* Addition and use of environment variables for specifying the concurrency and GPUs for the training and pipeline workers
* `run_pipeline` and `run_training` _should_ now only use the GPU specified from the environment variables mentioned above, if these variables were set. I say "should" because I don't have access to a machine with multiple GPUs besides the production server, and I haven't tested it there.

fixes #225 
fixes #224