### PR TITLE
[Critical bugfix] Migrate to pydantic

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -6,12 +6,12 @@ from setuptools import find_packages, setup
 requirements = [
     "cheroot>=8.4.5",  # https://github.com/cherrypy/cheroot/issues/312
     "girder==3.1.0",
+    "diva-boiler",
     "girder_jobs==3.0.3",
     "girder_worker==0.6.0",
     "girder_worker_utils==0.8.5",
+    "pydantic",
     "pysnooper",
-    "dacite",
-    "diva-boiler",
 ]
 
 setup(

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -9,19 +9,20 @@ test_tuple = [
     (
         [
             # all frames in a track must be of the same type, so the type name for 0 will be ignored
-            "0,1.png,0,884,510,1219,737,1,-1,ignored,1",
-            "0,2.png,1,111,222,3333,444,1,-1,typestring,1",
+            "0,1.png,0,884.66,510,1219.66,737.66,1,-1,ignored,0.98",
+            "0,2.png,1,111,222,3333,444,1,-1,typestring,0.55",
             "1,1.png,0,747,457,1039,633,1,-1,type2,1",
         ],
         {
             "0": {
                 "trackId": 0,
                 "attributes": {},
-                "confidencePairs": [["typestring", 1.0]],
+                "confidencePairs": [["typestring", 0.55]],
                 "features": [
                     {
                         "frame": 0,
-                        "bounds": [884, 510, 1219, 737],
+                        # NOTICE numbers that were rounded!
+                        "bounds": [885, 510, 1220, 738],
                         "keyframe": True,
                         "interpolate": False,
                     },
@@ -98,7 +99,4 @@ test_tuple = [
 @pytest.mark.parametrize("input,expected", test_tuple)
 def test_read_csv(input: List[str], expected: Dict[str, dict]):
     out_json = viame.load_csv_as_tracks(input)
-    print("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
-    print(json.dumps(out_json, sort_keys=True))
-    print(json.dumps(expected, sort_keys=True))
     assert json.dumps(out_json, sort_keys=True) == json.dumps(expected, sort_keys=True)

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -98,4 +98,7 @@ test_tuple = [
 @pytest.mark.parametrize("input,expected", test_tuple)
 def test_read_csv(input: List[str], expected: Dict[str, dict]):
     out_json = viame.load_csv_as_tracks(input)
+    print("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+    print(json.dumps(out_json, sort_keys=True))
+    print(json.dumps(expected, sort_keys=True))
     assert json.dumps(out_json, sort_keys=True) == json.dumps(expected, sort_keys=True)

--- a/server/viame_server/serializers/meva.py
+++ b/server/viame_server/serializers/meva.py
@@ -79,13 +79,15 @@ def load_kpf_as_tracks(ymls):
             print("WARNING: activity yaml was not given")
 
         tracks = parse_actor_map_to_tracks(actor_map)
-        return {trackId: track.dict(exclude_none=True) for trackId, track in tracks.items()}
+        return {
+            trackId: track.dict(exclude_none=True) for trackId, track in tracks.items()
+        }
     except Exception as e:
         error_report['error'] = str(e)
         return error_report
 
 
-def parse_actor_map_to_tracks(actor_map) -> Dict[int,Track]:
+def parse_actor_map_to_tracks(actor_map) -> Dict[int, Track]:
     tracks = {}
     ids = {}
     i = 1
@@ -103,9 +105,7 @@ def parse_actor_map_to_tracks(actor_map) -> Dict[int,Track]:
                 'geom_id': detection.geom_id,
             }
             feature = Feature(
-                frame=detection.frame,
-                bounds=bounds,
-                attributes=feat_attributes
+                frame=detection.frame, bounds=bounds, attributes=feat_attributes
             )
 
             # Create a new track per actor id

--- a/server/viame_server/serializers/meva.py
+++ b/server/viame_server/serializers/meva.py
@@ -2,7 +2,7 @@ import csv
 import io
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
@@ -80,7 +80,7 @@ def load_kpf_as_tracks(ymls):
             print("WARNING: activity yaml was not given")
 
         tracks = parse_actor_map_to_tracks(actor_map)
-        return {trackId: track.asdict() for trackId, track in tracks.items()}
+        return {trackId: asdict(track) for trackId, track in tracks.items()}
     except Exception as e:
         error_report['error'] = str(e)
         return error_report

--- a/server/viame_server/serializers/meva.py
+++ b/server/viame_server/serializers/meva.py
@@ -9,7 +9,6 @@ import yaml
 from boiler import models
 from boiler.definitions import ActorType
 from boiler.serialization import kpf
-from dacite import Config, from_dict
 from girder.models.file import File
 
 from viame_server.serializers.models import Feature, Track

--- a/server/viame_server/serializers/meva.py
+++ b/server/viame_server/serializers/meva.py
@@ -2,7 +2,7 @@ import csv
 import io
 import json
 import re
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
@@ -80,13 +80,13 @@ def load_kpf_as_tracks(ymls):
             print("WARNING: activity yaml was not given")
 
         tracks = parse_actor_map_to_tracks(actor_map)
-        return {trackId: asdict(track) for trackId, track in tracks.items()}
+        return {trackId: track.dict(exclude_none=True) for trackId, track in tracks.items()}
     except Exception as e:
         error_report['error'] = str(e)
         return error_report
 
 
-def parse_actor_map_to_tracks(actor_map):
+def parse_actor_map_to_tracks(actor_map) -> Dict[int,Track]:
     tracks = {}
     ids = {}
     i = 1
@@ -104,7 +104,9 @@ def parse_actor_map_to_tracks(actor_map):
                 'geom_id': detection.geom_id,
             }
             feature = Feature(
-                frame=detection.frame, bounds=bounds, attributes=feat_attributes
+                frame=detection.frame,
+                bounds=bounds,
+                attributes=feat_attributes
             )
 
             # Create a new track per actor id

--- a/server/viame_server/serializers/models.py
+++ b/server/viame_server/serializers/models.py
@@ -1,49 +1,44 @@
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
+from pydantic import BaseModel, Field
 
 
-@dataclass
-class GeoJSONGeometry:
+class GeoJSONGeometry(BaseModel):
     type: str
     coordinates: Union[List[List[float]], List[List[List[float]]]]
 
 
-@dataclass
-class GeoJSONFeature:
+class GeoJSONFeature(BaseModel):
     type: str
     geometry: GeoJSONGeometry
     properties: Dict[str, Union[bool, float, str]]
 
 
-@dataclass
-class GeoJSONFeatureCollection:
+class GeoJSONFeatureCollection(BaseModel):
     type: str
     features: List[GeoJSONFeature]
 
 
-@dataclass
-class Feature:
+class Feature(BaseModel):
     """Feature represents a single detection in a track."""
 
     frame: int
-    bounds: List[float]
+    bounds: List[int]
+    attributes: Optional[Dict[str, Union[bool, float, str]]]
     geometry: Optional[GeoJSONFeatureCollection] = None
     head: Optional[Tuple[float, float]] = None
     tail: Optional[Tuple[float, float]] = None
     fishLength: Optional[float] = None
-    attributes: Optional[Dict[str, Union[bool, float, str]]] = None
     interpolate: Optional[bool] = False
     keyframe: Optional[bool] = True
 
 
-@dataclass
-class Track:
+class Track(BaseModel):
     begin: int
     end: int
     trackId: int
-    features: List[Feature] = field(default_factory=lambda: [])
-    confidencePairs: List[Tuple[str, float]] = field(default_factory=lambda: [])
-    attributes: Dict[str, Any] = field(default_factory=lambda: {})
+    features: List[Feature] = Field(default_factory=lambda: [])
+    confidencePairs: List[Tuple[str, float]] = Field(default_factory=lambda: [])
+    attributes: Dict[str, Any] = Field(default_factory=lambda: {})
 
     def exceeds_thresholds(self, thresholds: Dict[str, float]) -> bool:
         defaultThresh = thresholds.get('default', 0)

--- a/server/viame_server/serializers/models.py
+++ b/server/viame_server/serializers/models.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
+
 from pydantic import BaseModel, Field
 
 

--- a/server/viame_server/serializers/models.py
+++ b/server/viame_server/serializers/models.py
@@ -35,10 +35,6 @@ class Feature:
     interpolate: Optional[bool] = False
     keyframe: Optional[bool] = True
 
-    def asdict(self):
-        """Removes entries with values of `None`."""
-        return {k: v for k, v in self.__dict__.items() if v is not None}
-
 
 @dataclass
 class Track:
@@ -48,15 +44,6 @@ class Track:
     features: List[Feature] = field(default_factory=lambda: [])
     confidencePairs: List[Tuple[str, float]] = field(default_factory=lambda: [])
     attributes: Dict[str, Any] = field(default_factory=lambda: {})
-
-    def asdict(self):
-        """Used instead of `dataclasses.asdict` for better performance."""
-
-        track_dict = dict(self.__dict__)
-        track_dict["features"] = [
-            feature.asdict() for feature in track_dict["features"]
-        ]
-        return track_dict
 
     def exceeds_thresholds(self, thresholds: Dict[str, float]) -> bool:
         defaultThresh = thresholds.get('default', 0)

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -123,7 +123,7 @@ def load_csv_as_tracks(rows: List[str]) -> Dict[str, dict]:
 
         for (key, val) in track_attributes:
             track.attributes[key] = val
-        
+
     return {trackId: track.dict(exclude_none=True) for trackId, track in tracks.items()}
 
 

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -6,6 +6,7 @@ import io
 import json
 import re
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from dataclasses import asdict
 
 from dacite import Config, from_dict
 from girder.models.file import File
@@ -125,7 +126,7 @@ def load_csv_as_tracks(rows: List[str]) -> Dict[str, dict]:
         for (key, val) in track_attributes:
             track.attributes[key] = val
 
-    return {trackId: track.asdict() for trackId, track in tracks.items()}
+    return {trackId: asdict(track) for trackId, track in tracks.items()}
 
 
 def export_tracks_as_csv(

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -6,9 +6,7 @@ import io
 import json
 import re
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
-from dataclasses import asdict
 
-from dacite import Config, from_dict
 from girder.models.file import File
 
 from viame_server.serializers.models import Feature, Track, interpolate
@@ -22,7 +20,7 @@ def valueToString(value):
     return str(value)
 
 
-def row_info(row: List[str]) -> Tuple[int, int, List[float], float]:
+def row_info(row: List[str]) -> Tuple[int, str, int, List[float], float]:
     trackId = int(row[0])
     filename = str(row[1])
     frame = int(row[2])
@@ -86,8 +84,8 @@ def _parse_row_for_tracks(row: List[str]) -> Tuple[Feature, Dict, Dict, List]:
     trackId, filename, frame, bounds, fishLength = row_info(row)
 
     feature = Feature(
-        frame,
-        bounds,
+        frame=frame,
+        bounds=bounds,
         attributes=attributes or None,
         fishLength=fishLength if fishLength > 0 else None,
         **head_tail_feature,
@@ -103,7 +101,7 @@ def load_csv_as_tracks(rows: List[str]) -> Dict[str, dict]:
     Expect detections to be in increasing order (either globally or by track).
     """
     reader = csv.reader(row for row in rows if (not row.startswith("#") and row))
-    tracks = {}
+    tracks: Dict[int, Track] = {}
     for row in reader:
         (
             feature,
@@ -115,7 +113,7 @@ def load_csv_as_tracks(rows: List[str]) -> Dict[str, dict]:
         trackId, _, frame, _, _ = row_info(row)
 
         if trackId not in tracks:
-            tracks[trackId] = Track(frame, frame, trackId)
+            tracks[trackId] = Track(begin=frame, end=frame, trackId=trackId)
 
         track = tracks[trackId]
         track.begin = min(frame, track.begin)
@@ -125,8 +123,8 @@ def load_csv_as_tracks(rows: List[str]) -> Dict[str, dict]:
 
         for (key, val) in track_attributes:
             track.attributes[key] = val
-
-    return {trackId: asdict(track) for trackId, track in tracks.items()}
+        
+    return {trackId: track.dict(exclude_none=True) for trackId, track in tracks.items()}
 
 
 def export_tracks_as_csv(
@@ -136,7 +134,7 @@ def export_tracks_as_csv(
     csvFile = io.StringIO()
     writer = csv.writer(csvFile)
     for t in track_dict.values():
-        track = from_dict(Track, t, config=Config(cast=[Tuple]))
+        track = Track(**t)
         if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):
 
             sorted_confidence_pairs = sorted(

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -4,7 +4,6 @@ import re
 import urllib
 from typing import Dict, Tuple
 
-from dacite import Config, from_dict
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import (
@@ -295,9 +294,7 @@ class ViameDetection(Resource):
         for track_id in delete:
             track_dict.pop(str(track_id), None)
         for track_id, track in upsert.items():
-            validated: models.Track = from_dict(
-                models.Track, track, config=Config(cast=[Tuple])
-            )
+            validated: models.Track = models.Track(**track)
             track_dict[str(track_id)] = validated.dict(exclude_none=True)
 
         upserted_len = len(upsert.keys())

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -3,7 +3,6 @@ import json
 import re
 import urllib
 from typing import Dict, Tuple
-import dataclasses
 
 from dacite import Config, from_dict
 from girder.api import access
@@ -299,7 +298,7 @@ class ViameDetection(Resource):
             validated: models.Track = from_dict(
                 models.Track, track, config=Config(cast=[Tuple])
             )
-            track_dict[str(track_id)] = dataclasses.asdict(validated)
+            track_dict[str(track_id)] = validated.dict(exclude_none=True)
 
         upserted_len = len(upsert.keys())
         deleted_len = len(delete)

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -3,6 +3,7 @@ import json
 import re
 import urllib
 from typing import Dict, Tuple
+import dataclasses
 
 from dacite import Config, from_dict
 from girder.api import access
@@ -298,7 +299,7 @@ class ViameDetection(Resource):
             validated: models.Track = from_dict(
                 models.Track, track, config=Config(cast=[Tuple])
             )
-            track_dict[str(track_id)] = validated.asdict()
+            track_dict[str(track_id)] = dataclasses.asdict(validated)
 
         upserted_len = len(upsert.keys())
         deleted_len = len(delete)


### PR DESCRIPTION
This has been broken for a while, I'm not sure how nobody noticed.  This is a bug I caused.


# Save error

```
girder_1         | ERROR:500 Error
girder_1         | Traceback (most recent call last):
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 629, in endpointDecorator
girder_1         |     val = fun(self, path, params)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 1208, in PUT
girder_1         |     return self.handleRoute('PUT', path, params)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 946, in handleRoute
girder_1         |     val = handler(**kwargs)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/access.py", line 57, in wrapped
girder_1         |     return fun(*args, **kwargs)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/describe.py", line 679, in wrapped
girder_1         |     return fun(*args, **kwargs)
girder_1         |   File "/home/viame_girder/viame_server/viame_detection.py", line 307, in save_detection
girder_1         |     saveTracks(folder, track_dict, user)
girder_1         |   File "/home/viame_girder/viame_server/utils.py", line 117, in saveTracks
girder_1         |     json_bytes = json.dumps(tracks).encode()
girder_1         |   File "/usr/lib/python3.7/json/__init__.py", line 231, in dumps
girder_1         |     return _default_encoder.encode(obj)
girder_1         |   File "/usr/lib/python3.7/json/encoder.py", line 199, in encode
girder_1         |     chunks = self.iterencode(o, _one_shot=True)
girder_1         |   File "/usr/lib/python3.7/json/encoder.py", line 257, in iterencode
girder_1         |     return _iterencode(o, 0)
girder_1         |   File "/usr/lib/python3.7/json/encoder.py", line 179, in default
girder_1         |     raise TypeError(f'Object of type {o.__class__.__name__} '
girder_1         | TypeError: Object of type GeoJSONFeatureCollection is not JSON serializable
girder_1         | Additional info:
girder_1         |   Request URL: PUT http://localhost:8010/api/v1/viame_detection
girder_1         |   Query string: folderId=5f2843e7ed4b41b97af22194
girder_1         |   Remote IP: 172.20.0.1
girder_1         |   Request UID: eb8f4ec9-6c1a-4f2d-a700-080ce56dbe78
girder_1         | INFO:rest.request

```

## Load error 

```
girder_1         | ERROR:500 Error
girder_1         | Traceback (most recent call last):
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 629, in endpointDecorator
girder_1         |     val = fun(self, path, params)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 1190, in GET
girder_1         |     return self.handleRoute('GET', path, params)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/rest.py", line 946, in handleRoute
girder_1         |     val = handler(**kwargs)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/access.py", line 57, in wrapped
girder_1         |     return fun(*args, **kwargs)
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/girder/api/describe.py", line 679, in wrapped
girder_1         |     return fun(*args, **kwargs)
girder_1         |   File "/home/viame_girder/viame_server/viame_detection.py", line 255, in get_detection
girder_1         |     file = self._load_detections(folder)
girder_1         |   File "/home/viame_girder/viame_server/viame_detection.py", line 86, in _load_detections
girder_1         |     file = Item().childFiles(detectionItems[0])[0]
girder_1         |   File "/opt/venv/lib/python3.7/site-packages/pymongo/cursor.py", line 649, in __getitem__
girder_1         |     raise IndexError("no such item for Cursor instance")
girder_1         | IndexError: no such item for Cursor instance
girder_1         | Additional info:
girder_1         |   Request URL: GET http://localhost:8010/api/v1/viame_detection
girder_1         |   Query string: folderId=5f2843e7ed4b41b97af22194&formatting=track_json
girder_1         |   Remote IP: 172.20.0.1
girder_1         |   Request UID: 066ee2fb-e5f2-479f-9bec-0c6f9737cc82
girder_1         | INFO:rest.request
```

our custom asdict wasn't doing deep serialization, so a python class instance was getting passed for the geometry object to `json.dumps()` which failed any time the user tried to save a polygon.

Right now, any polygon save will corrupt the user's tracks.  This is just another reason we need to migrate tracks into mongo: this whole json file thing is dangerous.

Anyway, it would be good if we could get this in before the deployment tonight.

On another note, having used both pydantic and dacite now extensively, there are no situations where dacite is better, IMO.  It handles recursive serialization/deserialization kinda poorly, the syntax is messier `from_dict` vs `Model(**dict)`, and the internal validation/coercion is better.  It will automatically round decimals to int during deserialization, for example. 