### PR TITLE
Allow annotations > filenames to not error

### DIFF
--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -198,7 +198,7 @@ def export_tracks_as_csv(
                         feature.fishLength or -1,
                     ]
 
-                    if filenames:
+                    if filenames and feature.frame < len(filenames):
                         columns[1] = filenames[feature.frame]
 
                     for pair in sorted_confidence_pairs:


### PR DESCRIPTION
If there are more annotations than filenames, don't throw a 500 out of range, just ignore it.