### PR TITLE
[BUG] fix feature.interpolate=true getting set for new detections, simplify logic. 

### DIFF
--- a/client/app/components/CreationMode.vue
+++ b/client/app/components/CreationMode.vue
@@ -88,7 +88,7 @@ export default Vue.extend({
           Mode:
         </v-col>
         <v-col>
-          <v-combobox
+          <v-select
             v-model="newTrackSettings.value.mode"
             class="ml-0 pa-0"
             x-small


### PR DESCRIPTION
# Bug

If you created a detection while track.interpolate was true, the detection would become a "Track" with interpolate=true.

There was also unnecessary complexity with newTrackMode and newDetectionMode: only a single state variable + `newTrackSettings.mode` was necessary to know.

Now, you can even change from track to detection while you're in the middle of creation (between track create and bounding box draw).

I consider this a critical fix, because for the demo, if I'm trying to explain the difference between detection and track, it's confusing to have detections acting like tracks in an unintended way.