### PR TITLE
Add sentry integration in prod

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,1 +1,2 @@
 VUE_APP_STATIC_PATH=./static/viame/
+VUE_APP_SENTRY_DSN=https://0ec02775cc734df98134cecf5c91f782@o267860.ingest.sentry.io/5436001

--- a/client/app/main.ts
+++ b/client/app/main.ts
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import VueCompositionApi from '@vue/composition-api';
 import NotificationBus from '@girder/components/src/utils/notifications';
+import { init as SentryInit } from '@sentry/browser';
+import { Vue as SentryVue } from '@sentry/integrations';
 
 import snackbarService from 'app/vue-utilities/snackbar-service';
 import promptService from 'app/vue-utilities/prompt-service';
@@ -17,6 +19,14 @@ Vue.use(VueCompositionApi);
 Vue.use(snackbarService(vuetify));
 Vue.use(promptService(vuetify));
 Vue.use(vMousetrap);
+
+SentryInit({
+  dsn: process.env.VUE_APP_SENTRY_DSN,
+  integrations: [
+    new SentryVue({ Vue, logErrors: true }),
+  ],
+  release: process.env.VUE_APP_GIT_HASH,
+});
 
 const notificationBus = new NotificationBus(girderRest);
 notificationBus.connect();

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,8 @@
     "@flatten-js/interval-tree": "^1.0.11",
     "@girder/components": "^2.2.4",
     "@mdi/font": "^3.9.97",
+    "@sentry/browser": "^5.24.2",
+    "@sentry/integrations": "^5.24.2",
     "@types/mousetrap": "^1.6.3",
     "@vue/composition-api": "^0.5.0",
     "axios": "^0.19.2",

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -104,7 +104,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
           if (this.type === 'Polygon' && this.selectedHandleIndex >= 0) {
             divisor = 2;
           }
-          setTimeout(() => this.redraw(), 0); //Redraw timeout to update the selected handle
+          window.setTimeout(() => this.redraw(), 0); //Redraw timeout to update the selected handle
           if (this.type !== 'rectangle') {
             this.bus.$emit('update:selectedIndex',
               this.selectedHandleIndex / divisor, this.type, this.selectedKey);
@@ -273,7 +273,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
       //For line drawings and the actions of any recipes we want
       if (this.annotator.geoViewer.interactor().mouse().buttons.left) {
         this.formattedData = this.formatData(frameData);
-        this.leftButtonCheckTimeout = setTimeout(() => this.changeData(frameData), 20);
+        this.leftButtonCheckTimeout = window.setTimeout(() => this.changeData(frameData), 20);
       } else {
         clearTimeout(this.leftButtonCheckTimeout);
         this.formattedData = this.formatData(frameData);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1509,6 +1509,68 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sentry/browser@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.24.2.tgz#e2c2786dbf07699ee12f12babf0138d633abc494"
+  integrity sha512-P/uZC/VrLRpU7MVEJnlZK5+AkEmuHu+mns5gC91Z4gjn7GamjR/CaXVedHGw/15ZrsQiAiwoWwuxpv4Ypd/+SA==
+  dependencies:
+    "@sentry/core" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/core@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.24.2.tgz#1724652855c0887a690c3fc6acd2519d4072b511"
+  integrity sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==
+  dependencies:
+    "@sentry/hub" "5.24.2"
+    "@sentry/minimal" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.24.2.tgz#64a02fd487599945e488ae23aba4ce4df44ee79e"
+  integrity sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==
+  dependencies:
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/integrations@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.24.2.tgz#cfb14c64465d6acbb279994b8a87a8ef72776320"
+  integrity sha512-b0upZS+xvONwxkLL6apSSgseR1e6dtq7wAGHefnPa5ckTwIoUkboL/dqiTNmFj1xXnWb87WDX1ZcIx7nfEqw6A==
+  dependencies:
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
+    localforage "1.8.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.24.2.tgz#14e8b136842398a32987459f0574359b6dc57a1f"
+  integrity sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==
+  dependencies:
+    "@sentry/hub" "5.24.2"
+    "@sentry/types" "5.24.2"
+    tslib "^1.9.3"
+
+"@sentry/types@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.24.2.tgz#e2c25d1e75d8dbec5dbbd9a309a321425b61c2ca"
+  integrity sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ==
+
+"@sentry/utils@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.24.2.tgz#90b7dff939bbbf4bb8edcac6aac2d04a0552af80"
+  integrity sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==
+  dependencies:
+    "@sentry/types" "5.24.2"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -8278,6 +8340,13 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -8348,6 +8417,13 @@ loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.0, loader-utils@^1.2
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+localforage@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.8.1.tgz#f6c0a24b41ab33b10e4dc84342dd696f6f3e3433"
+  integrity sha512-azSSJJfc7h4bVpi0PGi+SmLQKJl2/8NErI+LhJsrORNikMZnhaQ7rv9fHj+ofwgSHrKRlsDCL/639a6nECIKuQ==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Add sentry integration in production.

Note that `docker-compose up` results in a production build, so any errors in a local docker compose stack will get pushed to sentry.  I don't really care that much, but it might be a problem later.

Also, if anyone tries to run this stack on their own, they'll ship their errors to our sentry collection.  That may or may not actually be preferable.  Punt for now.

I'd like @AlmightyYakob to review this because I think he has used sentry a lot more than me.