### PR TITLE
Write access fix

### DIFF
--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -57,7 +57,7 @@ class Viame(Resource):
             model=Folder,
             paramType="query",
             required=True,
-            level=AccessType.READ,
+            level=AccessType.WRITE,
         )
         .param(
             "pipeline",

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -281,7 +281,7 @@ class ViameDetection(Resource):
             model=Folder,
             paramType="query",
             required=True,
-            level=AccessType.READ,
+            level=AccessType.WRITE,
         )
         .jsonParam(
             "tracks", "upsert and delete tracks", paramType="body", requireObject=True


### PR DESCRIPTION
Fixes the write access error.

Tested quickly.  Created a new account locally and tried to save a new detection on a folder.  Then tried to run a pipeline on another user's folder.  It properly responded with 403 error. Going to add an issue to prevent users from even having the option to save or run pipelines if it isn't their own.

 I will test once this is pushed to the server as well to ensure all settings for the collections.