### PR TITLE
Update girder_worker to fix failing builds

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "girder==3.1.0",
     "diva-boiler",
     "girder_jobs==3.0.3",
-    "girder_worker==0.6.0",
+    "girder_worker==0.8.0",
     "girder_worker_utils==0.8.5",
     "pydantic",
     "pysnooper",


### PR DESCRIPTION
This fixes the failing builds we've been seeing recently, caused by a bug I've documented [here](https://github.com/girder/girder_worker/issues/369). I've tested this locally and it seems to work without issue.