### PR TITLE
Smoke test feature array in constructor

### DIFF
--- a/client/src/track.spec.ts
+++ b/client/src/track.spec.ts
@@ -83,7 +83,7 @@ describe('Track', () => {
       meta: {},
       begin: 1,
       end: 1,
-      features: features,
+      features,
       confidencePairs: [['foo', 1]],
     })).toThrowError();
   });

--- a/client/src/track.spec.ts
+++ b/client/src/track.spec.ts
@@ -52,6 +52,7 @@ describe('Track', () => {
     expect(track.begin).toBe(1);
     expect(track.end).toBe(1);
   });
+
   it('should correctly reset begin and end on firstFeature', () => {
     const track = new Track(0, {
       meta: {},
@@ -72,5 +73,18 @@ describe('Track', () => {
     expect(f4).toStrictEqual([null, null, feature]);
     expect(track.begin).toBe(3);
     expect(track.end).toBe(3);
+  });
+
+  it('should fail to initialize with non-sparse array', () => {
+    const features = [
+      { frame: 1, bounds: [1, 2, 3, 4] as RectBounds, keyframe: true },
+    ];
+    expect(() => new Track(1, {
+      meta: {},
+      begin: 1,
+      end: 1,
+      features: features,
+      confidencePairs: [['foo', 1]],
+    })).toThrowError();
   });
 });

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -100,7 +100,7 @@ export default class Track {
     this.features = features; // NON-reactive sparse array
     this.featureIndex = [];
     this.revision = ref(1);
-    this.sanityCheckFeatures(features);
+    Track.sanityCheckFeatures(features);
     this.repopulateInterpolatedFrames(features);
     this.begin = begin;
     this.end = end;
@@ -111,12 +111,20 @@ export default class Track {
     return (this.end - this.begin) + 1;
   }
 
-  private sanityCheckFeatures(features: Feature[]) {
+  /**
+   * Test the first element in the feature array.  Its index should match
+   * its frame number.  Otherwise, the constructor was called with a
+   * dense array, which is incorrect.
+   */
+  private static sanityCheckFeatures(features: Feature[]) {
     const breakException = Symbol('breakException');
     try {
       features.forEach((f, i) => {
         if (f.frame !== i) {
-          throw new Error('features must be initialized with sparse array');
+          throw new Error(
+            'features must be initialized with sparse array.'
+            + 'Use Track.fromJson() if you want to initialize with features.',
+          );
         }
         throw breakException;
       });
@@ -133,7 +141,7 @@ export default class Track {
         this.featureIndex.push(f.frame);
       }
       if (!!f.keyframe !== !!f.bounds) {
-        throw new Error('keyframe must not XOR bounds')
+        throw new Error('keyframe must not XOR bounds');
       }
     });
   }

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -100,6 +100,7 @@ export default class Track {
     this.features = features; // NON-reactive sparse array
     this.featureIndex = [];
     this.revision = ref(1);
+    this.sanityCheckFeatures(features);
     this.repopulateInterpolatedFrames(features);
     this.begin = begin;
     this.end = end;
@@ -110,12 +111,29 @@ export default class Track {
     return (this.end - this.begin) + 1;
   }
 
+  private sanityCheckFeatures(features: Feature[]) {
+    const breakException = Symbol('breakException');
+    try {
+      features.forEach((f, i) => {
+        if (f.frame !== i) {
+          throw new Error('features must be initialized with sparse array');
+        }
+        throw breakException;
+      });
+    } catch (e) {
+      if (e !== breakException) throw e;
+    }
+  }
+
   private repopulateInterpolatedFrames(features: Feature[]) {
     this.featureIndex = [];
     features.forEach((f) => {
       // TODO: Figure out what the conditions are for this.
-      if (f.bounds) {
+      if (f.keyframe && f.bounds) {
         this.featureIndex.push(f.frame);
+      }
+      if (!!f.keyframe !== !!f.bounds) {
+        throw new Error('keyframe must not XOR bounds')
       }
     });
   }


### PR DESCRIPTION
Better error handling for track contstructor.  If you need to construct a new track initialized with features, use `fromJson()`, not `new Track()`.   See the new test case for an explanation.

## Wrong

``` typescript
const features = [
      { frame: 1, bounds: [1, 2, 3, 4] as RectBounds, keyframe: true },
    ];
    new Track(1, {
      meta: {},
      begin: 1,
      end: 1,
      features: features,
      confidencePairs: [['foo', 1]],
    });
```

## Right

``` typescript
const itrack: TrackData = {
      attributes: {},
      begin: 0,
      end: 100,
      confidencePairs: [
        ['foo', 1],
        ['bar', 0.9],
      ],
      features: [
        {
          frame: 0,
          bounds: [1, 2, 3, 4],
          head: [1, 2],
        },
      ],
      meta: {},
      trackId: 1,
    };
    const t = Track.fromJSON(itrack);
```