### PR TITLE
Remove use of alias inside library

### DIFF
--- a/client/app/components/DeleteControls.vue
+++ b/client/app/components/DeleteControls.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import { EditAnnotationTypes } from 'vue-media-annotator/layers/EditAnnotationLayer';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers/';
 
 export default Vue.extend({
   name: 'DeleteControls',

--- a/client/app/components/EditorMenu.vue
+++ b/client/app/components/EditorMenu.vue
@@ -3,7 +3,7 @@ import { flatten } from 'lodash';
 import Vue, { PropType } from 'vue';
 
 import { Mousetrap } from 'vue-media-annotator/types';
-import { EditAnnotationTypes } from 'vue-media-annotator/layers/EditAnnotationLayer';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers';
 import Recipe from 'vue-media-annotator/recipe';
 
 interface ButtonData {

--- a/client/app/recipes/headtail.ts
+++ b/client/app/recipes/headtail.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 
 import Track from 'vue-media-annotator/track';
 import Recipe, { UpdateResponse } from 'vue-media-annotator/recipe';
-import { EditAnnotationTypes } from 'vue-media-annotator/layers/EditAnnotationLayer';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers';
 import { Mousetrap } from 'vue-media-annotator/types';
 
 export const HeadTailLineKey = 'HeadTails';

--- a/client/app/recipes/polygonbase.ts
+++ b/client/app/recipes/polygonbase.ts
@@ -5,7 +5,7 @@ import Vue from 'vue';
 import { removePoint } from 'vue-media-annotator/utils';
 import Track from 'vue-media-annotator/track';
 import Recipe from 'vue-media-annotator/recipe';
-import { EditAnnotationTypes } from 'vue-media-annotator/layers/EditAnnotationLayer';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers';
 
 const EmptyResponse = { data: {}, union: [], unionWithoutBounds: [] };
 

--- a/client/app/use/useModeManager.ts
+++ b/client/app/use/useModeManager.ts
@@ -4,7 +4,7 @@ import {
 import { uniq, flatMapDeep } from 'lodash';
 import Track, { TrackId } from 'vue-media-annotator/track';
 import { RectBounds, updateBounds } from 'vue-media-annotator/utils';
-import { EditAnnotationTypes } from 'vue-media-annotator/layers/EditAnnotationLayer';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers';
 
 import Recipe from 'vue-media-annotator/recipe';
 import { NewTrackSettings } from './useSettings';

--- a/client/app/views/TrackViewer/ControlsContainer.vue
+++ b/client/app/views/TrackViewer/ControlsContainer.vue
@@ -2,12 +2,13 @@
 import {
   defineComponent, ref, PropType,
 } from '@vue/composition-api';
-import Controls from 'vue-media-annotator/components/controls/Controls.vue';
-import TimelineWrapper from 'vue-media-annotator/components/controls/TimelineWrapper.vue';
-import Timeline from 'vue-media-annotator/components/controls/Timeline.vue';
-import LineChart from 'vue-media-annotator/components/controls/LineChart.vue';
-import EventChart from 'vue-media-annotator/components/controls/EventChart.vue';
-import TooltipBtn from 'vue-media-annotator/components/TooltipButton.vue';
+import {
+  Controls,
+  EventChart,
+  LineChart,
+  Timeline,
+  TimelineWrapper,
+} from 'vue-media-annotator/components';
 
 export default defineComponent({
   components: {
@@ -16,7 +17,6 @@ export default defineComponent({
     LineChart,
     Timeline,
     TimelineWrapper,
-    TooltipBtn,
   },
 
   props: {

--- a/client/app/views/TrackViewer/Sidebar.vue
+++ b/client/app/views/TrackViewer/Sidebar.vue
@@ -6,8 +6,7 @@ import {
   PropType,
 } from '@vue/composition-api';
 
-import TypeList from 'vue-media-annotator/components/TypeList.vue';
-import TrackList from 'vue-media-annotator/components/TrackList.vue';
+import { TypeList, TrackList } from 'vue-media-annotator/components';
 import { useAllTypes } from 'vue-media-annotator/provides';
 
 import { NewTrackSettings } from 'app/use/useSettings';

--- a/client/app/views/TrackViewer/Viewer.vue
+++ b/client/app/views/TrackViewer/Viewer.vue
@@ -14,9 +14,11 @@ import {
   useEventChart,
 } from 'vue-media-annotator/use';
 import { provideAnnotator } from 'vue-media-annotator/provides';
-import VideoAnnotator from 'vue-media-annotator/components/annotators/VideoAnnotator.vue';
-import ImageAnnotator from 'vue-media-annotator/components/annotators/ImageAnnotator.vue';
-import LayerManager from 'vue-media-annotator/components/LayerManager.vue';
+import {
+  ImageAnnotator,
+  VideoAnnotator,
+  LayerManager,
+} from 'vue-media-annotator/components';
 
 import PolygonBase from 'app/recipes/polygonbase';
 import HeadTail from 'app/recipes/headtail';

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -6,17 +6,17 @@ import {
   watch,
 } from '@vue/composition-api';
 
-import { Annotator } from 'vue-media-annotator/components/annotators/annotatorType';
-import RectangleLayer from 'vue-media-annotator/layers/AnnotationLayers/RectangleLayer';
-import PolygonLayer from 'vue-media-annotator/layers/AnnotationLayers/PolygonLayer';
-import PointLayer from 'vue-media-annotator/layers/AnnotationLayers/PointLayer';
-import LineLayer from 'vue-media-annotator/layers/AnnotationLayers/LineLayer';
+import { Annotator } from './annotators/annotatorType';
+import RectangleLayer from '../layers/AnnotationLayers/RectangleLayer';
+import PolygonLayer from '../layers/AnnotationLayers/PolygonLayer';
+import PointLayer from '../layers/AnnotationLayers/PointLayer';
+import LineLayer from '../layers/AnnotationLayers/LineLayer';
 
-import EditAnnotationLayer, { EditAnnotationTypes } from 'vue-media-annotator/layers/EditAnnotationLayer';
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
-import TextLayer from 'vue-media-annotator/layers/TextLayer';
-import Track, { TrackId } from 'vue-media-annotator/track';
-import { geojsonToBound } from 'vue-media-annotator/utils';
+import EditAnnotationLayer, { EditAnnotationTypes } from '../layers/EditAnnotationLayer';
+import { FrameDataTrack } from '../layers/LayerTypes';
+import TextLayer from '../layers/TextLayer';
+import Track, { TrackId } from '../track';
+import { geojsonToBound } from '../utils';
 
 import {
   useEnabledTracks,
@@ -28,7 +28,7 @@ import {
   useVisibleModes,
   useSelectedKey,
   useStateStyles,
-} from 'vue-media-annotator/provides';
+} from '../provides';
 
 /** LayerManager is a component intended to be used as a child of an Annotator.
  *  It provides logic for switching which layers are visible, but more importantly

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -2,9 +2,9 @@
 import {
   defineComponent, computed, watch, reactive, PropType, toRef, ref,
 } from '@vue/composition-api';
-import TooltipBtn from 'vue-media-annotator/components/TooltipButton.vue';
-import { useFrame } from 'vue-media-annotator/provides';
-import Track from 'vue-media-annotator/track';
+import TooltipBtn from './TooltipButton.vue';
+import { useFrame } from '../provides';
+import Track from '../track';
 
 export default defineComponent({
   name: 'TrackItem',

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -3,8 +3,8 @@ import Vue from 'vue';
 import {
   defineComponent, reactive, computed, ref, Ref, watch,
 } from '@vue/composition-api';
-import TrackItem from 'vue-media-annotator/components/TrackItem.vue';
-import Track, { TrackId } from 'vue-media-annotator/track';
+
+import Track, { TrackId } from '../track';
 import {
   useAllTypes,
   useCheckedTrackIds,
@@ -13,7 +13,8 @@ import {
   useTrackMap,
   useTracks,
   useTypeStyling,
-} from 'vue-media-annotator/provides';
+} from '../provides';
+import TrackItem from './TrackItem.vue';
 
 interface VirtualListItem {
   track: Track;

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -1,0 +1,29 @@
+import ImageAnnotator from './annotators/ImageAnnotator.vue';
+import VideoAnnotator from './annotators/VideoAnnotator.vue';
+
+import Controls from './controls/Controls.vue';
+import EventChart from './controls/EventChart.vue';
+import LineChart from './controls/LineChart.vue';
+import Timeline from './controls/Timeline.vue';
+import TimelineWrapper from './controls/TimelineWrapper.vue';
+
+import LayerManager from './LayerManager.vue';
+import TooltipButton from './TooltipButton.vue';
+import TrackItem from './TrackItem.vue';
+import TrackList from './TrackList.vue';
+import TypeList from './TypeList.vue';
+
+export {
+  ImageAnnotator,
+  VideoAnnotator,
+  Controls,
+  EventChart,
+  LineChart,
+  Timeline,
+  TimelineWrapper,
+  LayerManager,
+  TooltipButton,
+  TrackItem,
+  TrackList,
+  TypeList,
+};

--- a/client/src/layers/AnnotationLayers/LineLayer.ts
+++ b/client/src/layers/AnnotationLayers/LineLayer.ts
@@ -1,7 +1,8 @@
 /* eslint-disable class-methods-use-this */
-import BaseLayer, { LayerStyle, BaseLayerParams } from 'vue-media-annotator/layers/BaseLayer';
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
 import { cloneDeep } from 'lodash';
+
+import BaseLayer, { LayerStyle, BaseLayerParams } from '../BaseLayer';
+import { FrameDataTrack } from '../LayerTypes';
 
 interface LineGeoJSData{
   trackId: number;

--- a/client/src/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/layers/AnnotationLayers/PolygonLayer.ts
@@ -1,7 +1,8 @@
 /* eslint-disable class-methods-use-this */
-import BaseLayer, { LayerStyle, BaseLayerParams } from 'vue-media-annotator/layers/BaseLayer';
 import geo, { GeoEvent } from 'geojs';
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
+
+import BaseLayer, { LayerStyle, BaseLayerParams } from '../BaseLayer';
+import { FrameDataTrack } from '../LayerTypes';
 
 interface PolyGeoJSData{
   trackId: number;

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -1,8 +1,9 @@
 /* eslint-disable class-methods-use-this */
-import BaseLayer, { LayerStyle, BaseLayerParams } from 'vue-media-annotator/layers/BaseLayer';
-import { boundToGeojson } from 'vue-media-annotator/utils';
 import geo, { GeoEvent } from 'geojs';
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
+
+import { boundToGeojson } from '../../utils';
+import BaseLayer, { LayerStyle, BaseLayerParams } from '../BaseLayer';
+import { FrameDataTrack } from '../LayerTypes';
 
 interface RectGeoJSData{
   trackId: number;

--- a/client/src/layers/BaseLayer.ts
+++ b/client/src/layers/BaseLayer.ts
@@ -1,9 +1,10 @@
 /*eslint class-methods-use-this: "off"*/
-import { Annotator } from 'vue-media-annotator/components/annotators/annotatorType';
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
-import { StateStyles, TypeStyling } from 'vue-media-annotator/use/useStyling';
 import Vue from 'vue';
 import { Ref } from '@vue/composition-api';
+
+import { Annotator } from '../components/annotators/annotatorType';
+import { StateStyles, TypeStyling } from '../use/useStyling';
+import { FrameDataTrack } from './LayerTypes';
 
 // eslint-disable-next-line max-len
 export type StyleFunction<T, D> = T | ((point: [number, number], index: number, data: D) => T | undefined);

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -1,8 +1,9 @@
 /*eslint class-methods-use-this: "off"*/
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
-import BaseLayer, { BaseLayerParams, LayerStyle } from 'vue-media-annotator/layers/BaseLayer';
-import { boundToGeojson } from 'vue-media-annotator/utils';
 import geo, { GeoEvent } from 'geojs';
+
+import { boundToGeojson } from '../utils';
+import { FrameDataTrack } from './LayerTypes';
+import BaseLayer, { BaseLayerParams, LayerStyle } from './BaseLayer';
 
 export type EditAnnotationTypes = 'Point' | 'rectangle' | 'Polygon' | 'LineString';
 interface EditAnnotationLayerParams {

--- a/client/src/layers/LayerTypes.ts
+++ b/client/src/layers/LayerTypes.ts
@@ -1,4 +1,4 @@
-import { Feature } from 'vue-media-annotator/track';
+import { Feature } from '../track';
 
 export interface FrameDataTrack {
   selected: boolean;

--- a/client/src/layers/TextLayer.ts
+++ b/client/src/layers/TextLayer.ts
@@ -1,5 +1,5 @@
-import BaseLayer, { LayerStyle } from 'vue-media-annotator/layers/BaseLayer';
-import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
+import BaseLayer, { LayerStyle } from './BaseLayer';
+import { FrameDataTrack } from './LayerTypes';
 
 interface TextData {
   selected: boolean;

--- a/client/src/layers/index.ts
+++ b/client/src/layers/index.ts
@@ -1,0 +1,16 @@
+import EditAnnotationLayer, { EditAnnotationTypes } from './EditAnnotationLayer';
+import LineLayer from './AnnotationLayers/LineLayer';
+import PointLayer from './AnnotationLayers/PointLayer';
+import PolygonLayer from './AnnotationLayers/PolygonLayer';
+import RectangleLayer from './AnnotationLayers/RectangleLayer';
+import TextLayer from './TextLayer';
+
+export {
+  EditAnnotationLayer,
+  EditAnnotationTypes,
+  LineLayer,
+  PointLayer,
+  PolygonLayer,
+  RectangleLayer,
+  TextLayer,
+};

--- a/client/src/track.spec.ts
+++ b/client/src/track.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 import Vue from 'vue';
 import CompositionApi from '@vue/composition-api';
-import Track, { TrackData } from 'vue-media-annotator/track';
+import Track, { TrackData } from './track';
 import { RectBounds } from './utils';
 
 Vue.use(CompositionApi);

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -1,12 +1,12 @@
 import Vue from 'vue';
 import { Ref, ref } from '@vue/composition-api';
-import { RectBounds } from 'vue-media-annotator/utils';
+import { RectBounds } from './utils';
 import {
   binarySearch,
   listInsert,
   getSurroundingElements,
   listRemove,
-} from 'vue-media-annotator/listUtils';
+} from './listUtils';
 
 export type InterpolateFeatures = [Feature | null, Feature | null, Feature | null];
 export type ConfidencePair = [string, number];

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -1,8 +1,7 @@
 
 import { computed, Ref } from '@vue/composition-api';
-import Track, { TrackId } from 'vue-media-annotator/track';
+import Track, { TrackId } from '../track';
 import { TypeStyling } from './useStyling';
-
 
 interface EventChartParams {
   enabledTracks: Readonly<Ref<readonly Track[]>>;

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -1,5 +1,5 @@
 import { computed, Ref } from '@vue/composition-api';
-import Track from 'vue-media-annotator/track';
+import Track from '../track';
 import { TypeStyling } from './useStyling';
 
 interface UseLineChartParams {

--- a/client/src/use/useTrackFilters.ts
+++ b/client/src/use/useTrackFilters.ts
@@ -1,8 +1,8 @@
 import {
   ref, computed, Ref, watch,
 } from '@vue/composition-api';
-import Track, { TrackId } from 'vue-media-annotator/track';
-import { updateSubset } from 'vue-media-annotator/utils';
+import Track, { TrackId } from '../track';
+import { updateSubset } from '../utils';
 
 /* Provide track filtering controls on tracks loaded from useTrackStore. */
 export default function useFilteredTracks(

--- a/client/src/use/useTrackSelectionControls.spec.ts
+++ b/client/src/use/useTrackSelectionControls.spec.ts
@@ -1,8 +1,8 @@
 /// <reference types="jest" />
 import Vue from 'vue';
 import CompositionApi, { computed } from '@vue/composition-api';
-import useTrackSelectionControls from 'vue-media-annotator/use/useTrackSelectionControls';
-import Track from 'vue-media-annotator/track';
+import Track from '../track';
+import useTrackSelectionControls from './useTrackSelectionControls';
 
 Vue.use(CompositionApi);
 

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -1,5 +1,5 @@
 import { ref, Ref } from '@vue/composition-api';
-import Track, { TrackId } from 'vue-media-annotator/track';
+import Track, { TrackId } from '../track';
 
 /* Maintain references to the selected Track, selected detection,
  * editing state, etc.

--- a/client/src/use/useTrackStore.spec.ts
+++ b/client/src/use/useTrackStore.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 import Vue from 'vue';
 import CompositionApi, { watchEffect } from '@vue/composition-api';
-import useTrackStore from 'vue-media-annotator/use/useTrackStore';
+import useTrackStore from './useTrackStore';
 
 Vue.use(CompositionApi);
 

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -1,6 +1,6 @@
 import { ref, Ref, computed } from '@vue/composition-api';
-import Track, { TrackId } from 'vue-media-annotator/track';
 import IntervalTree from '@flatten-js/interval-tree';
+import Track, { TrackId } from '../track';
 
 interface UseTrackStoreParams {
   markChangesPending: (type: 'upsert' | 'delete', track?: Track) => void;

--- a/client/src/utils.spec.ts
+++ b/client/src/utils.spec.ts
@@ -1,5 +1,5 @@
 /// <reference types="jest" />
-import { updateSubset } from 'vue-media-annotator/utils';
+import { updateSubset } from './utils';
 
 describe('updateSubset', () => {
   it('should return null for identical sets', () => {


### PR DESCRIPTION
Removes `vue-media-annotator` alias from the library portion of the app. Keep using it in the app part.

Blocked on #361 
fixes #304 