### PR TITLE
Use provide.handler instead of emit

### DIFF
--- a/client/app/use/useModeManager.ts
+++ b/client/app/use/useModeManager.ts
@@ -123,14 +123,18 @@ export default function useModeManager({
     creating = false;
   }
 
-  function handleAddTrackOrDetection() {
+  function handleAddTrackOrDetection(): TrackId {
     // Handles adding a new track with the NewTrack Settings
-    selectTrack(addTrack(frame.value, newTrackSettings.type).trackId, true);
+    const newTrackId = addTrack(frame.value, newTrackSettings.type).trackId;
+    selectTrack(newTrackId, true);
     creating = true;
+    return newTrackId;
   }
 
-  function handleTrackTypeChange({ trackId, value }: { trackId: TrackId; value: string }) {
-    getTrack(trackId).setType(value);
+  function handleTrackTypeChange(trackId: TrackId | null, value: string) {
+    if (trackId !== null) {
+      getTrack(trackId).setType(value);
+    }
   }
 
   function newTrackSettingsAfterLogic(addedTrack: Track) {
@@ -326,13 +330,15 @@ export default function useModeManager({
     }
   }
 
-  function handleRemoveTrack(trackId: TrackId) {
-    // if removed track was selected, unselect before remove
-    if (selectedTrackId.value === trackId) {
-      const newTrack = selectNextTrack(1) !== null ? selectNextTrack(1) : selectNextTrack(-1);
-      selectTrack(newTrack, false);
+  function handleRemoveTrack(trackId: TrackId | null) {
+    if (trackId !== null) {
+      // if removed track was selected, unselect before remove
+      if (selectedTrackId.value === trackId) {
+        const newTrack = selectNextTrack(1) !== null ? selectNextTrack(1) : selectNextTrack(-1);
+        selectTrack(newTrack, false);
+      }
+      removeTrack(trackId);
     }
-    removeTrack(trackId);
   }
 
   /** Toggle editing mode for track */
@@ -387,14 +393,14 @@ export default function useModeManager({
     selectedFeatureHandle,
     selectedKey,
     handler: {
-      selectTrack: handleSelectTrack,
+      trackAdd: handleAddTrackOrDetection,
       trackEdit: handleTrackEdit,
+      trackSeek: handleTrackClick,
+      trackSelect: handleSelectTrack,
+      trackSelectNext: handleSelectNext,
       trackTypeChange: handleTrackTypeChange,
-      addTrack: handleAddTrackOrDetection,
       updateRectBounds: handleUpdateRectBounds,
       updateGeoJSON: handleUpdateGeoJSON,
-      selectNext: handleSelectNext,
-      trackClick: handleTrackClick,
       removeTrack: handleRemoveTrack,
       removePoint: handleRemovePoint,
       removeAnnotation: handleRemoveAnnotation,

--- a/client/app/views/TrackViewer/Sidebar.vue
+++ b/client/app/views/TrackViewer/Sidebar.vue
@@ -78,12 +78,7 @@ export default defineComponent({
         key="type-tracks"
         class="wrapper d-flex flex-column"
       >
-        <type-list
-          class="flex-shrink-1 flex-grow-1 typelist"
-          @update-type-name="$emit('update-type-name',$event)"
-          @update-type-style="$emit('update-type-style',$event)"
-          @update-checked-types="$emit('update-checked-types', $event)"
-        />
+        <type-list class="flex-shrink-1 flex-grow-1 typelist" />
         <slot />
         <v-spacer />
         <v-divider />
@@ -92,15 +87,6 @@ export default defineComponent({
           :new-track-mode="newTrackSettings.mode"
           :new-track-type="newTrackSettings.type"
           :hotkeys-disabled="$prompt.visible()"
-          @track-remove="$emit('track-remove', $event)"
-          @track-add="$emit('track-add')"
-          @track-click="$emit('track-click', $event)"
-          @track-checked="$emit('track-checked', $event)"
-          @track-edit="$emit('track-edit', $event)"
-          @track-type-change="$emit('track-type-change', $event)"
-          @track-previous="$emit('track-previous')"
-          @track-next="$emit('track-next')"
-          @track-split="$emit('track-split', $event)"
           @track-seek="$emit('track-seek', $event)"
         >
           <template slot="settings">

--- a/client/app/views/TrackViewer/Viewer.vue
+++ b/client/app/views/TrackViewer/Viewer.vue
@@ -190,7 +190,7 @@ export default defineComponent({
       removeTrack,
     });
 
-    async function splitTracks(trackId: TrackId | undefined, _frame: number) {
+    async function trackSplit(trackId: TrackId | null, _frame: number) {
       if (typeof trackId === 'number') {
         const track = getTrack(trackId);
         let newtracks: [Track, Track];
@@ -213,18 +213,18 @@ export default defineComponent({
           return;
         }
         const wasEditing = editingTrack.value;
-        handler.selectTrack(null);
+        handler.trackSelect(null);
         tsRemoveTrack(trackId);
         insertTrack(newtracks[0]);
         insertTrack(newtracks[1]);
-        handler.selectTrack(newtracks[1].trackId, wasEditing);
+        handler.trackSelect(newtracks[1].trackId, wasEditing);
       }
     }
 
     function save() {
       // If editing the track, disable editing mode before save
       if (editingTrack.value) {
-        handler.selectTrack(selectedTrackId.value, false);
+        handler.trackSelect(selectedTrackId.value, false);
       }
       saveToServer({
         customTypeStyling: getTypeStyles(allTypes),
@@ -240,6 +240,15 @@ export default defineComponent({
     const dataPath = computed(() => (
       getPathFromLocation(ctx.root.$store.state.Location.location)));
 
+    const globalHandler = {
+      ...handler,
+      setCheckedTypes: updateCheckedTypes,
+      trackSplit,
+      trackEnable: updateCheckedTrackId,
+      updateTypeName,
+      updateTypeStyle,
+    };
+
     provideAnnotator(
       allTypes,
       checkedTrackIds,
@@ -247,6 +256,7 @@ export default defineComponent({
       editingMode,
       enabledTracks,
       frame,
+      globalHandler,
       intervalTree,
       trackMap,
       filteredTracks,
@@ -281,17 +291,11 @@ export default defineComponent({
       videoUrl,
       visibleModes,
       /* methods */
-      addTrack,
-      handler,
+      handler: globalHandler,
       markChangesPending,
       save,
       saveThreshold,
-      splitTracks,
-      updateCheckedTrackId,
-      updateCheckedTypes,
       updateNewTrackSettings,
-      updateTypeStyle,
-      updateTypeName,
     };
   },
 });
@@ -369,20 +373,8 @@ export default defineComponent({
     >
       <sidebar
         v-bind="{ newTrackSettings }"
-        @track-add="handler.addTrack"
-        @track-remove="handler.removeTrack"
-        @track-click="handler.trackClick"
-        @track-checked="updateCheckedTrackId"
-        @track-edit="handler.trackEdit"
-        @track-next="handler.selectNext(1)"
-        @track-previous="handler.selectNext(-1)"
-        @track-type-change="handler.trackTypeChange($event)"
         @update-new-track-settings="updateNewTrackSettings($event)"
-        @track-split="splitTracks($event, frame)"
         @track-seek="playbackComponent.seek($event)"
-        @update-type-style="updateTypeStyle($event)"
-        @update-type-name="updateTypeName($event)"
-        @update-checked-types="updateCheckedTypes($event)"
       >
         <ConfidenceFilter
           :confidence.sync="confidenceThreshold"
@@ -395,9 +387,9 @@ export default defineComponent({
           v-if="imageData.length || videoUrl"
           ref="playbackComponent"
           v-mousetrap="[
-            { bind: 'n', handler: () => handler.addTrack },
+            { bind: 'n', handler: () => handler.trackAdd },
             { bind: 'r', handler: () => playbackComponent.resetZoom() },
-            { bind: 'esc', handler: () => handler.selectTrack(null, false)}
+            { bind: 'esc', handler: () => handler.trackSelect(null, false)}
           ]"
           v-bind="{ imageData, videoUrl, frameRate }"
           class="playback-component"
@@ -406,15 +398,10 @@ export default defineComponent({
           <template slot="control">
             <controls-container
               v-bind="{ lineChartData, eventChartData }"
-              @select-track="handler.selectTrack"
+              @select-track="handler.trackSelect"
             />
           </template>
-          <layer-manager
-            @select-track="handler.selectTrack"
-            @select-feature-handle="handler.selectFeatureHandle"
-            @update-rect-bounds="handler.updateRectBounds"
-            @update-geojson="handler.updateGeoJSON"
-          />
+          <layer-manager />
         </component>
       </v-col>
     </v-row>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-annotator",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "serve": "rimraf -rf ./node_modules/.cache/vue-loader && vue-cli-service serve app/main.ts",
     "build": "vue-cli-service build app/main.ts",

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -20,6 +20,7 @@ import { geojsonToBound } from '../utils';
 
 import {
   useEnabledTracks,
+  useHandler,
   useIntervalTree,
   useTrackMap,
   useSelectedTrackId,
@@ -36,7 +37,8 @@ import {
  *  LayerManager emits high-level events when track features get selected or updated.
  */
 export default defineComponent({
-  setup(props, { emit }) {
+  setup() {
+    const handler = useHandler();
     const intervalTree = useIntervalTree();
     const trackMap = useTrackMap();
     const tracksRef = useEnabledTracks();
@@ -217,14 +219,14 @@ export default defineComponent({
       //So we only want to pass the click whjen not in creation mode or editing mode for features
       if (editAnnotationLayer.getMode() !== 'creation') {
         editAnnotationLayer.disable();
-        emit('select-track', trackId, editing);
+        handler.trackSelect(trackId, editing);
       }
     };
 
 
     //Sync of internal geoJS state with the application
     editAnnotationLayer.bus.$on('editing-annotation-sync', (editing: boolean) => {
-      emit('select-track', selectedTrackIdRef.value, editing);
+      handler.trackSelect(selectedTrackIdRef.value, editing);
     });
     rectAnnotationLayer.bus.$on('annotation-clicked', Clicked);
     rectAnnotationLayer.bus.$on('annotation-right-clicked', Clicked);
@@ -240,9 +242,9 @@ export default defineComponent({
       if (type === 'rectangle') {
         const bounds = geojsonToBound(data as GeoJSON.Feature<GeoJSON.Polygon>);
         cb();
-        emit('update-rect-bounds', frameNumberRef.value, bounds);
+        handler.updateRectBounds(frameNumberRef.value, bounds);
       } else {
-        emit('update-geojson', mode, frameNumberRef.value, data, key, cb);
+        handler.updateGeoJSON(mode, frameNumberRef.value, data, key, cb);
       }
       //We update the current layer if not in progress so it jumps back into edit mode
       if (mode !== 'in-progress') {
@@ -257,7 +259,7 @@ export default defineComponent({
       }
     });
     editAnnotationLayer.bus.$on('update:selectedIndex',
-      (index: number, _type: EditAnnotationTypes, key = '') => emit('select-feature-handle', index, key));
+      (index: number, _type: EditAnnotationTypes, key = '') => handler.selectFeatureHandle(index, key));
   },
 });
 </script>

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -3,7 +3,7 @@ import {
   defineComponent, computed, watch, reactive, PropType, toRef, ref,
 } from '@vue/composition-api';
 import TooltipBtn from './TooltipButton.vue';
-import { useFrame } from '../provides';
+import { useFrame, useHandler } from '../provides';
 import Track from '../track';
 
 export default defineComponent({
@@ -41,6 +41,7 @@ export default defineComponent({
   setup(props, { root, emit }) {
     const vuetify = root.$vuetify;
     const frameRef = useFrame();
+    const handler = useHandler();
     const trackTypeRef = toRef(props, 'trackType');
     const typeInputBoxRef = ref(undefined as undefined | HTMLInputElement);
     const data = reactive({
@@ -104,7 +105,7 @@ export default defineComponent({
       if (data.trackTypeValue === '') {
         data.trackTypeValue = props.trackType;
       } else if (data.trackTypeValue !== props.trackType) {
-        emit('type-change', data.trackTypeValue);
+        handler.trackTypeChange(props.track.trackId, data.trackTypeValue);
       }
     }
 
@@ -165,6 +166,7 @@ export default defineComponent({
       focusType,
       gotoNext,
       gotoPrevious,
+      handler,
       onBlur,
       onFocus,
       toggleInterpolation,
@@ -189,7 +191,7 @@ export default defineComponent({
         hide-details
         :input-value="inputValue"
         :color="color"
-        @change="$emit('change', $event)"
+        @change="handler.trackEnable(track.trackId, $event)"
       />
       <v-tooltip
         open-delay="200"
@@ -201,7 +203,7 @@ export default defineComponent({
           <div
             class="trackNumber pl-0 pr-2"
             v-on="on"
-            @click.self="$emit('click')"
+            @click.self="handler.trackSeek(track.trackId)"
           >
             {{ track.trackId }}
           </div>
@@ -229,7 +231,7 @@ export default defineComponent({
           color="error"
           icon="mdi-delete"
           :tooltip-text="`Delete ${isTrack ? 'Track' : 'Detection'}`"
-          @click="$emit('delete')"
+          @click="handler.removeTrack(track.trackId)"
         />
 
         <tooltip-btn
@@ -237,7 +239,7 @@ export default defineComponent({
           :disabled="!track.canSplit(frame)"
           icon="mdi-call-split"
           tooltip-text="Split Track"
-          @click="$emit('split')"
+          @click="handler.trackSplit(track.trackId, frame)"
         />
 
         <tooltip-btn
@@ -296,7 +298,7 @@ export default defineComponent({
         :icon="(editing) ? 'mdi-pencil-box' : 'mdi-pencil-box-outline'"
         tooltip-text="Toggle edit mode"
         :disabled="!inputValue"
-        @click="$emit('edit')"
+        @click="handler.trackEdit(track.trackId)"
       />
     </v-row>
   </div>

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
 import { defineComponent, reactive } from '@vue/composition-api';
-import { useCheckedTypes, useAllTypes, useTypeStyling } from '../provides';
+import {
+  useCheckedTypes, useAllTypes, useTypeStyling, useHandler,
+} from '../provides';
 
 export default defineComponent({
   name: 'TypeList',
 
-  setup(props, { emit }) {
+  setup() {
     const data = reactive({
       showPicker: false,
       selectedColor: '',
@@ -20,6 +22,11 @@ export default defineComponent({
     const checkedTypesRef = useCheckedTypes();
     const allTypesRef = useAllTypes();
     const typeStylingRef = useTypeStyling();
+    const {
+      updateTypeName,
+      updateTypeStyle,
+      setCheckedTypes,
+    } = useHandler();
 
     function clickEdit(type: string) {
       data.selectedType = type;
@@ -34,12 +41,12 @@ export default defineComponent({
     function acceptChanges() {
       data.showPicker = false;
       if (data.editingType !== data.selectedType) {
-        emit('update-type-name', {
+        updateTypeName({
           currentType: data.selectedType,
           newType: data.editingType,
         });
       }
-      emit('update-type-style', {
+      updateTypeStyle({
         type: data.editingType,
         color: data.editingColor,
         strokeWidth: data.editingThickness,
@@ -56,6 +63,7 @@ export default defineComponent({
       /* methods */
       acceptChanges,
       clickEdit,
+      setCheckedTypes,
     };
   },
 });
@@ -83,7 +91,7 @@ export default defineComponent({
               shrink
               hide-details
               class="my-1 type-checkbox"
-              @change="$emit('update-checked-types', $event)"
+              @change="setCheckedTypes"
             />
             <v-spacer />
             <v-tooltip

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -4,6 +4,7 @@ import { provide, inject, Ref } from '@vue/composition-api';
 import { StateStyles, TypeStyling } from './use/useStyling';
 import { EditAnnotationTypes } from './layers/EditAnnotationLayer';
 import Track, { TrackId } from './track';
+import { RectBounds } from './utils';
 
 /**
  * Provides declares the dependencies that a consumer must provide before
@@ -55,6 +56,63 @@ type StateStylesType = Readonly<StateStyles>;
 const VisibleModesSymbol = Symbol('visibleModes');
 type VisibleModesType = Readonly<Ref<readonly EditAnnotationTypes[]>>;
 
+/**
+ * Handler interface describes all global events mutations
+ * for above state
+ */
+export interface Handler {
+  /* Select and seek to track */
+  trackSeek(trackId: TrackId): void;
+  /* Toggle editing mode for track */
+  trackEdit(trackId: TrackId): void;
+  /* set checked track ids */
+  trackEnable(trackId: TrackId, value: boolean): void;
+  /* toggle selection mode for track */
+  trackSelect(trackId: TrackId | null, edit: boolean): void;
+  /* select next track in the list */
+  trackSelectNext(delta: number): void;
+  /* split track */
+  trackSplit(trackId: TrackId | null, frame: number): void;
+  /* Change tracks difinitive type */
+  trackTypeChange(trackId: TrackId | null, value: string): void;
+  /* Add new empty track and select it */
+  trackAdd(): TrackId;
+  /* update Rectangle bounds for track */
+  updateRectBounds(
+    frameNum: number,
+    bounds: RectBounds,
+  ): void;
+  /* update geojson for track */
+  updateGeoJSON(
+    eventType: 'in-progress' | 'editing',
+    frameNum: number,
+    data: GeoJSON.Feature,
+    key?: string,
+    preventInterrupt?: () => void,
+  ): void;
+  /* Remove a whole track */
+  removeTrack(trackId: (TrackId | null)): void;
+  /* Remove a single point from selected track's geometry by selected index */
+  removePoint(): void;
+  /* Remove an entire annotation from selected track by selected key */
+  removeAnnotation(): void;
+  /* set selectFeatureHandle and selectedKey */
+  selectFeatureHandle(i: number, key: string): void;
+  /* set checked type strings */
+  setCheckedTypes(types: string[]): void;
+  /* Change type name */
+  updateTypeName({ currentType, newType }: { currentType: string; newType: string }): void;
+  /* change styles */
+  updateTypeStyle(args: {
+    type: string;
+    color?: string;
+    strokeWidth?: number;
+    opacity?: number;
+    fill?: boolean;
+  }): void;
+}
+const HandlerSymbol = Symbol('handler');
+
 function _handleMissing(s: symbol): Error {
   return new Error(`Missing provided object for symbol ${s.toString()}: must provideAnnotator()`);
 }
@@ -74,6 +132,7 @@ function provideAnnotator(
   editingMode: EditingModeType,
   enabledTracks: EnabledTracksType,
   frame: FrameType,
+  handler: Handler,
   intervalTree: IntervalTreeType,
   trackMap: TrackMapType,
   tracks: TracksType,
@@ -97,6 +156,7 @@ function provideAnnotator(
   provide(SelectedTrackIdSymbol, selectedTrackId);
   provide(StateStylesSymbol, stateStyles);
   provide(VisibleModesSymbol, visibleModes);
+  provide(HandlerSymbol, handler);
 }
 
 function useAllTypes() {
@@ -121,6 +181,10 @@ function useEditingMode() {
 
 function useFrame() {
   return _use<FrameType>(FrameSymbol);
+}
+
+function useHandler() {
+  return _use<Handler>(HandlerSymbol);
 }
 
 function useIntervalTree() {
@@ -162,6 +226,7 @@ export {
   useCheckedTypes,
   useEnabledTracks,
   useEditingMode,
+  useHandler,
   useIntervalTree,
   useFrame,
   useTrackMap,

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -31,13 +31,6 @@ export interface TypeStyling {
   opacity: (type: string) => number;
 }
 
-interface UpdateStylingArgs {
-  type: string;
-  color?: string;
-  strokeWidth?: number;
-  opacity?: number;
-  fill?: boolean;
-}
 interface UseStylingParams {
   markChangesPending: () => void;
 }
@@ -125,7 +118,13 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     }
   }
 
-  function updateTypeStyle(args: UpdateStylingArgs) {
+  function updateTypeStyle(args: {
+    type: string;
+    color?: string;
+    strokeWidth?: number;
+    opacity?: number;
+    fill?: boolean;
+  }) {
     const { type } = args;
     if (!customStyles.value[type]) {
       VueSet(customStyles.value, type, {});

--- a/client/src/use/useTrackFilters.ts
+++ b/client/src/use/useTrackFilters.ts
@@ -107,7 +107,7 @@ export default function useFilteredTracks(
     checkedTypes.value = types;
   }
 
-  function updateCheckedTrackId({ trackId, value }: { trackId: TrackId; value: boolean }) {
+  function updateCheckedTrackId(trackId: TrackId, value: boolean) {
     if (value) {
       checkedTrackIds.value.push(trackId);
     } else {


### PR DESCRIPTION
This is the logical sibling of my provides PR to circumvent the type loss happening in emitters.

This has a certain elegance to it: the ability to globally use a collection of state and handlers without having to prescribe a specific implementation like Vuex requires.

Downstream retains full control such that it can maintain additional state and modify behaviors based on that hidden state, but the interface is fixed (which it was all along, there just wasn't a formalization).

I haven't tested this too thoroughly, but I'm happy with the style.

I'm considering implementing a sort of dummy handler for use cases like Jake where only parts will be used.  Basically an abstract base class.