### PR TITLE
Fixes failed pipelines deleting annotations

### DIFF
--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -68,7 +68,6 @@ class Viame(Resource):
     def run_pipeline_task(self, folder, pipeline):
         user = self.getCurrentUser()
         token = Token().createToken(user=user, days=1)
-        move_existing_result_to_auxiliary_folder(folder, user)
         input_type = folder["meta"]["type"]
         return run_pipeline.delay(
             GetPathFromFolderId(str(folder["_id"])),


### PR DESCRIPTION
Really small change and I hope I'm not missing any side effects of this.

It looks like `move_existing_result_to_auxiliary_folder` is called before running a pipeline.  If that pipeline fails to produce a usable CSV file or is cancelled the track data is already in auxiliary folder meaning you can't load it back up again.

It looks like `saveTracks` which is called in the `/postprocess` already includes a call to `move_existing_result_to_auxiliary_folder` which will move the old item into auxiliary only after the process successfully completes.  I believe that the post process won't do anything if it doesn't detect an existing CSV in the folder so if it fails it shouldn't move the current tracks to the auxiliary.

So the old one will only be moved a new call to saveTracks is made.  Replication of the issue this fixes is in the linked bug.

fixes #375