### PR TITLE
Add `null` type for `trackId` in `removeTrack`

### DIFF
--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -83,7 +83,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
     return track;
   }
 
-  function removeTrack(trackId: TrackId): void {
+  function removeTrack(trackId: TrackId | null): void {
     if (trackId === null) {
       return;
     }


### PR DESCRIPTION
The function handles `null` anyway, so this shouldn't change anything, but it would allow for a well-typed default case if no track is selected. Something I found myself wanting on MPF.