### PR TITLE
Keep girder_data folder alive

### DIFF
--- a/docker/girder_data/.gitignore
+++ b/docker/girder_data/.gitignore
@@ -1,0 +1,3 @@
+# ignore everything
+*
+!.gitignore


### PR DESCRIPTION
`girder_data` folder is mounted with docker compose, this will keep the directory checked in.