### PR TITLE
Fix process hanging when training with SVM config

### DIFF
--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -328,7 +328,7 @@ def convert_video(self, path, folderId, auxiliaryFolderId):
         process, process_log_file, process_err_file
     )
 
-    output = str(stdout) + "\n" + str(stderr)
+    output = stdout + "\n" + stderr
     self.job_manager.write(output)
     new_file = self.girder_client.uploadFileToFolder(folderId, output_path)
     self.girder_client.addMetadataToItem(new_file['itemId'], {"codec": "h264"})

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -11,10 +11,10 @@ from girder_worker.app import app
 from GPUtil import getGPUs
 
 from viame_tasks.utils import (
-    organize_folder_for_training,
-    read_and_close_process_outputs,
-    trained_pipeline_folder as _trained_pipeline_folder,
+  organize_folder_for_training,
+  read_and_close_process_outputs,
 )
+from viame_tasks.utils import trained_pipeline_folder as _trained_pipeline_folder
 
 
 def get_gpu_environment() -> Dict[str, str]:

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -11,8 +11,8 @@ from girder_worker.app import app
 from GPUtil import getGPUs
 
 from viame_tasks.utils import (
-  organize_folder_for_training,
-  read_and_close_process_outputs,
+    organize_folder_for_training,
+    read_and_close_process_outputs,
 )
 from viame_tasks.utils import trained_pipeline_folder as _trained_pipeline_folder
 

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -2,6 +2,31 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import mktemp
+from subprocess import Popen
+
+from typing import Optional, Tuple, IO
+
+
+def read_and_close_process_outputs(
+    process: Popen,
+    stdout_file: Optional[IO] = None,
+    stderr_file: Optional[IO] = None,
+) -> Tuple[str, str]:
+    stdout: str = ""
+    stderr: str = ""
+
+    process.wait()
+    if stdout_file is not None:
+        stdout_file.seek(0)
+        stdout = str(stdout_file.read())
+        stdout_file.close()
+
+    if stderr_file is not None:
+        stderr_file.seek(0)
+        stderr = str(stderr_file.read())
+        stderr_file.close()
+
+    return (stdout, stderr)
 
 
 def trained_pipeline_folder():

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -1,10 +1,9 @@
 import os
 import shutil
 from pathlib import Path
-from tempfile import mktemp
 from subprocess import Popen
-
-from typing import Optional, Tuple, IO
+from tempfile import mktemp
+from typing import IO, Optional, Tuple
 
 
 def read_and_close_process_outputs(

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -18,12 +18,12 @@ def read_and_close_process_outputs(
     process.wait()
     if stdout_file is not None:
         stdout_file.seek(0)
-        stdout = str(stdout_file.read())
+        stdout = stdout_file.read().decode()
         stdout_file.close()
 
     if stderr_file is not None:
         stderr_file.seek(0)
-        stderr = str(stderr_file.read())
+        stderr = stderr_file.read().decode()
         stderr_file.close()
 
     return (stdout, stderr)


### PR DESCRIPTION
This was due to an error in our use of `subprocess`, and the fact that using `subprocess.PIPE` to capture `stdout`/`stderr` can lead to hanging processes if there's enough output. [This](https://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/) article describes the problem well. This changes all of our calls to `Popen` to instead use temporary files to capture this output. I may try to refine this to make it less work on the caller of `read_and_close_process_outputs`, but I think it would be fine to merge as is.

I've tested this on a server with a GPU to confirm it stops the SVM training from hanging.