### PR TITLE
Remove lingering running/cancelling jobs on girder start

### DIFF
--- a/client/app/components/RunTrainingMenu.vue
+++ b/client/app/components/RunTrainingMenu.vue
@@ -75,7 +75,7 @@ export default {
 <template>
   <v-menu
     v-model="menuOpen"
-    max-width="320"
+    max-width="500"
     offset-y
     :close-on-content-click="false"
   >
@@ -105,7 +105,7 @@ export default {
 
     <template>
       <v-card v-if="trainingConfigurations">
-        <v-card-title>
+        <v-card-title class="pb-1">
           Run Training
         </v-card-title>
 
@@ -113,6 +113,14 @@ export default {
           Specify the name of the resulting pipeline
           and configuration file to use for training.
         </v-card-text>
+
+        <v-alert
+          dense
+          type="warning"
+        >
+          This instance is updated on Sunday at 2AM EST.
+          If your training job is running at that time it may be restarted/killed.
+        </v-alert>
 
         <v-text-field
           v-model="trainingOutputName"

--- a/docker/ansible/viame-deploy.timer
+++ b/docker/ansible/viame-deploy.timer
@@ -3,8 +3,6 @@ Description=Run the Viame deploy every Sunday and Thursday at 2 AM
 
 [Timer]
 OnCalendar=Sun 02:00 America/New_York
-OnCalendar=Thu 02:00 America/New_York
-Persistent=true
 
 [Install]
 WantedBy=timers.target

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,10 @@ x-worker: &base-worker
     - pipelines:${VIAME_PIPELINES_PATH}:ro
     - trained-pipelines:${VIAME_TRAINED_PIPELINES_PATH}
   depends_on:
-    - rabbit
+    girder:
+        condition: service_healthy
+    rabbit:
+        condition: service_started
   environment:
     - VIAME_PIPELINES_PATH=${VIAME_PIPELINES_PATH}
     - VIAME_TRAINED_PIPELINES_PATH=${VIAME_TRAINED_PIPELINES_PATH}
@@ -36,10 +39,13 @@ services:
       context: ../
       dockerfile: docker/girder.Dockerfile
     image: kitware/viame-web:${TAG:-latest}
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:8080"]
+        interval: 5s
+        timeout: 5s
+        retries: 5
     depends_on:
       - mongo
-      - girder_worker_pipelines
-      - girder_worker_training
     ports:
       - "8010:8080"
     volumes:

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -44,7 +44,7 @@ class Config:
         )
 
 
-@app.task(bind=True)
+@app.task(bind=True, acks_late=True)
 def run_pipeline(self, input_path, output_folder, pipeline, input_type):
     conf = Config()
 
@@ -155,7 +155,7 @@ def run_pipeline(self, input_path, output_folder, pipeline, input_type):
     os.remove(detector_output_path)
 
 
-@app.task(bind=True)
+@app.task(bind=True, acks_late=True)
 def train_pipeline(
     self,
     results_folder: Dict,
@@ -270,7 +270,7 @@ def train_pipeline(
             )
 
 
-@app.task(bind=True)
+@app.task(bind=True, acks_late=True)
 def convert_video(self, path, folderId, auxiliaryFolderId):
     # Delete is true, so the tempfile is deleted when the block closes.
     # We are only using this to get a name, and recreating it below.
@@ -343,7 +343,7 @@ def convert_video(self, path, folderId, auxiliaryFolderId):
     os.remove(output_path)
 
 
-@app.task(bind=True)
+@app.task(bind=True, acks_late=True)
 def convert_images(self, folderId):
     """
     Ensures that all images in a folder are in a web friendly format (png or jpeg).


### PR DESCRIPTION
~~Currently, these jobs are simply deleted when the server is spun up. Ideally, these jobs would be restarted, but so far attempts to do so result in new jobs remaining in an inactive state. I'd like to complete this task fully, but for now I think it's good to have this in here.~~ I've also added a warning to the client, so that users know that their training job could be killed if it's still running when the server is updated.

I've taken the advice of @subdavis, now if the server is restarted, existing running tasks will be restarted.