### PR TITLE
Add github action for publish workflow

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'
-    - run: yarn install
+    - run: yarn install --frozen-lockfile
     - run: yarn lint
     - run: yarn lint:templates
     - run: yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: NPM Publish
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    defaults:
+      run:
+        working-directory: client
+    name: Release to NPM
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # "ref" specifies the branch to check out.
+        # "github.event.release.target_commitish" is a global variable and specifies the branch the release targeted
+        ref: ${{ github.event.release.target_commitish }}
+    - name: Use Node 10
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+        # Specifies the registry, this field is required!
+        registry-url: https://registry.npmjs.org/
+    - run: yarn install --frozen-lockfile
+    # set up git since we will later push to the repo
+    - run: git config --global user.name "GitHub Bot"
+    - run: git config --global user.email "viame-web@kitware.com"
+    # Run some sanity checks
+    - run: yarn lint
+    - run: yarn lint:templates
+    - run: yarn test
+    # Build and publish
+    - run: yarn build:lib
+    - run: yarn publish --new-version ${{ github.event.release.tag_name }}
+      env:
+        # Use a token to publish to NPM.  Must configure this!
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # push the version changes to GitHub
+    - run: git push
+      env:
+        # The secret is passed automatically. Nothing to configure.
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/client/README.md
+++ b/client/README.md
@@ -26,6 +26,10 @@ yarn lint
 
 See [this issue](https://github.com/vuejs/vue-cli/issues/3065) for details on why our `yarn serve` command is weird.
 
+## Publishing
+
+Create a new release tagged `X.X.X` through github.
+
 ## Architecture
 
 ### src/components/annotators

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-annotator",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.2",
   "scripts": {
     "serve": "vue-cli-service serve platform/web-girder/main.ts",
     "build:web": "vue-cli-service build platform/web-girder/main.ts",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-annotator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "serve": "vue-cli-service serve platform/web-girder/main.ts",
     "build:web": "vue-cli-service build platform/web-girder/main.ts",


### PR DESCRIPTION
This will allow us to publish `vue-media-annotator` by creating a release through github UI.

You must be sure that the release tag is `X.X.X` and greater than the last version released.  