### PR TITLE
Upgrade CI tests to run in Node 14.15 LTS

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '14.x'
     - run: yarn install --frozen-lockfile
     - run: yarn lint
     - run: yarn lint:templates


### PR DESCRIPTION
Upgrade to node 14.15 LTS because 10 is ancient.

**You should probably upgrade your local NodeJS version to 14 or 15 too.**