### PR TITLE
Fixes FPS issue and image caching

### DIFF
--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -35,8 +35,8 @@ export default Vue.extend({
     this.imgs = new Array(this.imageData.length);
     this.filename = this.imageData[this.frame].filename;
     this.pendingImgs = new Set();
-    this.cacheImages();
     if (this.imgs.length) {
+      this.loadFrame(0);
       const img = this.imgs[0];
       img.onload = () => {
         img.onload = null;
@@ -44,6 +44,7 @@ export default Vue.extend({
         this.height = img.naturalHeight;
         img.cached = true;
         this.init();
+        this.cacheImages();
       };
     }
   },

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -93,7 +93,8 @@ export default defineComponent({
             throw new Error(`Cannot parse fps=${fps.value} as integer`);
           }
           return parsed;
-        } if (typeof fps.value === 'number') {
+        }
+        if (typeof fps.value === 'number') {
           return fps.value;
         }
       }

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -93,6 +93,8 @@ export default defineComponent({
             throw new Error(`Cannot parse fps=${fps.value} as integer`);
           }
           return parsed;
+        } if (typeof fps.value === 'number') {
+          return fps.value;
         }
       }
       return 10;


### PR DESCRIPTION
Fixes #420

FPS fix - the FPS was automatically a number so it was failing in the computed property to return the proper value and was defaulting everything to 10.

Image Cache fix - The original image caching would cache 6 seconds of data initially for image sequences.  This works for standard images but not for 16MB+ images.  It's trying to load all 7 images (at 1 frame per second) without any order priority so the first image may be the last to load.  I defaulted to loading the initial image first, then followed by caching so you can move through at least some images quickly and the system isn't sitting there doing nothing while you gawk at the first image.

Please test and make sure I didn't completely mess something up.