### PR TITLE
Add checkbuild.sh

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -20,8 +20,15 @@ yarn build:web
 # build vue-media-server library
 yarn build:lib
 
+# build electron
+yarn build:electron
+
 # lint
 yarn lint
+yarn lint:templates
+
+# Local verification of all tests, linting, builds
+./checkbuild.sh
 ```
 
 See [this issue](https://github.com/vuejs/vue-cli/issues/3065) for details on why our `yarn serve` command is weird.

--- a/client/checkbuild.sh
+++ b/client/checkbuild.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e # exit immediately on fail
+
+# This script is intended as an optional local utility.
+# CI runs are expensive, so you can use this to run all
+# CI Checks locally in parallel to verify that a commit will pass
+# in much less time than CI would take.
+
+yarn test &
+yarn lint &
+yarn lint:templates &
+yarn build:web &
+yarn build:electron &
+yarn build:lib &
+
+time wait 

--- a/client/package.json
+++ b/client/package.json
@@ -110,7 +110,11 @@
       "ts-jest": {
         "tsConfig": "tsconfig.spec.json"
       }
-    }
+    },
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/",
+      "<rootDir>/dist_electron/"
+    ]
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
I get a little impatient waiting for CI to run 10 minutes worth of checks, so this script will perform the same steps as CI in parallel.  It takes roughly 90 seconds on my machine.

That way you can be confident that your commit is functional before you push and waste less time fixing minor CI errors.

I don't want to add this as a commit hook.  It takes too long, and often I need to create a transient broken commit.