### PR TITLE
Allow setting of arbitrary attributes on video player

### DIFF
--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -12,6 +12,10 @@ export default Vue.extend({
       type: String,
       required: true,
     },
+    muted: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
@@ -25,6 +29,7 @@ export default Vue.extend({
     this.video = video;
     video.preload = 'auto';
     video.src = this.videoUrl;
+    video.muted = this.muted;
     video.onloadedmetadata = () => {
       video.onloadedmetadata = null;
       this.width = video.videoWidth;

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -12,9 +12,9 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    muted: {
-      type: Boolean,
-      default: false,
+    videoPlayerAttributes: {
+      type: Object,
+      default: () => ({}),
     },
   },
 
@@ -29,7 +29,9 @@ export default Vue.extend({
     this.video = video;
     video.preload = 'auto';
     video.src = this.videoUrl;
-    video.muted = this.muted;
+    Object.entries(this.videoPlayerAttributes).forEach(([key, val]) => {
+      this.video[key] = val;
+    });
     video.onloadedmetadata = () => {
       video.onloadedmetadata = null;
       this.width = video.videoWidth;


### PR DESCRIPTION
# Example

`<video-annotator :video-player-attributes="{ muted: true, loop: true }" />`

You can absolutely footgun with this.  But I wanted to expose all possible configuration rather than having explicit props for everything.

I put it below `src, preload` to allow hacking on those, but above `onloadMetadata` because that would be unreasonable to try to hack.
