### PR TITLE
Add dummy generators

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-annotator",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "scripts": {
     "serve": "vue-cli-service serve platform/web-girder/main.ts",
     "serve:electron": "vue-cli-service electron:serve",

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -311,22 +311,24 @@ export default defineComponent({
     };
 
     provideAnnotator(
-      allTypes,
-      usedTypes,
-      checkedTrackIds,
-      checkedTypes,
-      editingMode,
-      enabledTracks,
-      frame,
+      {
+        allTypes,
+        usedTypes,
+        checkedTrackIds,
+        checkedTypes,
+        editingMode,
+        enabledTracks,
+        frame,
+        intervalTree,
+        trackMap,
+        tracks: filteredTracks,
+        typeStyling,
+        selectedKey,
+        selectedTrackId,
+        stateStyles: stateStyling,
+        visibleModes,
+      },
       globalHandler,
-      intervalTree,
-      trackMap,
-      filteredTracks,
-      typeStyling,
-      selectedKey,
-      selectedTrackId,
-      stateStyling,
-      visibleModes,
     );
 
     return {


### PR DESCRIPTION
**This is a breaking change, and will upgrade to `1.1.0`.**

* Change arguments to `provideAnnotator` to accept an object, because the positional args were getting out of hand.
* Add methods to generate dummy state and a dummy handler compliant with the interface so that they can be easily overridden by downstream apps with much simpler needs.


## Example

``` typescript
provideAnnotator(
  { ...dummyState(), tracks: myTracks },
  dummyHandler(() => {}),
);
```

@AlmightyYakob and I have talked about this change