### PR TITLE
Minor ui fixes

### DIFF
--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -31,8 +31,9 @@ export default defineComponent({
   },
   // TODO: This will require an import from vue-router for Vue3 compatibility
   async beforeRouteLeave(to, from, next) {
-    await this.viewerRef.navigateAwayGuard();
-    next();
+    if (await this.viewerRef.navigateAwayGuard()) {
+      next();
+    }
   },
   setup(props, { root, refs }) {
     const dataset = toRef(root.$store.state.Dataset, 'dataset');

--- a/client/src/components/annotators/annotator.js
+++ b/client/src/components/annotators/annotator.js
@@ -95,10 +95,10 @@ export default {
         // The action below is needed to have GeoJS use the proper handler
         // with cancelOnMove for right clicks
         {
-          action: 'geo_action_select',
+          action: geo.geo_action.select,
           input: { right: true },
           name: 'button edit',
-          owner: 'geo.MapIteractor',
+          owner: 'geo.MapInteractor',
         },
         interactorOpts.actions[2],
         interactorOpts.actions[6],

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -276,9 +276,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
   }
 
   calculateCursorImage() {
-    if (this.getMode() === 'editing') {
-      this.annotator.$emit('set-image-cursor', 'mdi-pencil');
-    } else if (this.getMode() === 'creation') {
+    if (this.getMode() === 'creation') {
       // TODO:  we may want to make this more generic or utilize the icons from editMenu
       this.annotator.$emit('set-image-cursor', `mdi-vector-${typeMapper.get(this.type)}`);
     }

--- a/client/viame-web-common/components/RunPipelineMenu.vue
+++ b/client/viame-web-common/components/RunPipelineMenu.vue
@@ -71,7 +71,7 @@ export default defineComponent({
         case 'trained':
           return 'trained';
         case 'generate':
-          return 'utility';
+          return 'utilities';
         default:
           return `${pipeType}s`;
       }

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -288,8 +288,8 @@ export default defineComponent({
         result = await prompt({
           title: 'Save Items',
           text: 'There is unsaved data, would you like to continue or cancel and save?',
-          positiveButton: 'Continue',
-          negativeButton: 'Cancel',
+          positiveButton: 'Discard and Leave',
+          negativeButton: 'Don\'t Leave',
           confirm: true,
         });
       }

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -287,14 +287,11 @@ export default defineComponent({
       if (pendingSaveCount.value > 0) {
         result = await prompt({
           title: 'Save Items',
-          text: 'There is unsaved data, what would you like to do?',
-          positiveButton: 'Save',
-          negativeButton: 'Discard',
+          text: 'There is unsaved data, would you like to continue or cancel and save?',
+          positiveButton: 'Continue',
+          negativeButton: 'Cancel',
           confirm: true,
         });
-        if (result) {
-          await save();
-        }
       }
       return result;
     }


### PR DESCRIPTION
Just some really minor UI fixes to reduce the backlog

- Fixed the `annotator.js` references to `geo_actiton_select` and the owner
- Fixes #409 - changes the text and allows the user to prevent themselves from exiting the current view
- Fixes #278 - just a text change which shouldn't be used as a key anywhere else
- Fixes #388 - remove the pencil icon while in editing mode, left the others so you know what type you are drawing
