### PR TITLE
Server/csv header timestamp

### DIFF
--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -206,5 +206,7 @@ test_tuple = [
 
 @pytest.mark.parametrize("input,expected", test_tuple)
 def test_write_csv(input: Dict[str, dict], expected: List[str]):
-    for i, line in enumerate(viame.export_tracks_as_csv(input, filenames=filenames)):
+    for i, line in enumerate(
+        viame.export_tracks_as_csv(input, filenames=filenames, header=False)
+    ):
         assert line.strip(' ').rstrip() == expected[i]

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -2,11 +2,34 @@
 VIAME Fish format deserializer
 """
 import csv
+import datetime
 import io
 import re
 from typing import Dict, Generator, List, Tuple, Union
 
 from viame_server.serializers.models import Feature, Track, interpolate
+
+
+def writeHeader(writer: '_csv._writer'):
+    writer.writerow(
+        [
+            "# 1: Detection or Track-id",
+            "2: Video or Image Identifier",
+            "3: Unique Frame Identifier",
+            "4-7: Img-bbox(TL_x",
+            "TL_y",
+            "BR_x",
+            "BR_y)",
+            "8: Detection or Length Confidence",
+            "9: Target Length (0 or -1 if invalid)",
+            "10-11+: Repeated Species",
+            "Confidence Pairs or Attributes",
+        ]
+    )
+
+    writer.writerow(
+        [f'# Written on {datetime.datetime.now().ctime()} by: viame_web_csv_writer']
+    )
 
 
 def valueToString(value):
@@ -163,11 +186,18 @@ def load_csv_as_tracks(rows: List[str]) -> Dict[str, dict]:
 
 
 def export_tracks_as_csv(
-    track_dict, excludeBelowThreshold=False, thresholds={}, filenames=None
+    track_dict,
+    excludeBelowThreshold=False,
+    thresholds={},
+    filenames=None,
+    fps=None,
+    header=True,
 ) -> Generator[str, None, None]:
     """Export track json to a CSV format."""
     csvFile = io.StringIO()
     writer = csv.writer(csvFile)
+    if header:
+        writeHeader(writer)
     for t in track_dict.values():
         track = Track(**t)
         if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):
@@ -196,7 +226,13 @@ def export_tracks_as_csv(
                         feature.fishLength or -1,
                     ]
 
-                    if filenames and feature.frame < len(filenames):
+                    # If FPS is set, column 2 will be video timestamp
+                    if fps is not None and fps > 0:
+                        columns[1] = datetime.datetime.utcfromtimestamp(
+                            feature.frame / fps
+                        ).strftime(r'%H:%M:%S.%f')
+                    # else if filenames is set, column 2 will be image file name
+                    elif filenames and feature.frame < len(filenames):
                         columns[1] = filenames[feature.frame]
 
                     for pair in sorted_confidence_pairs:
@@ -233,7 +269,7 @@ def export_tracks_as_csv(
                                     f"(kp) {geoJSONFeature.properties['key']} {round(coordinates[0])} {round(coordinates[1])}"
                                 )
                             # TODO: support for multiple GeoJSON Objects of the same type once the CSV supports it
-
+                    print(columns)
                     writer.writerow(columns)
                     yield csvFile.getvalue()
                     csvFile.seek(0)

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -193,7 +193,17 @@ def export_tracks_as_csv(
     fps=None,
     header=True,
 ) -> Generator[str, None, None]:
-    """Export track json to a CSV format."""
+    """Export track json to a CSV format.
+    :exlcudeBelowThreshold: omit tracks below a certain confidence.  Requires thresholds.
+
+    :thresholds: key/value paris with threshold values
+
+    :filenames: list of string file names.  filenames[n] should be the image at frame n
+
+    :fps: if FPS is set, column 2 will be video timestamp derived from (frame / fps)
+
+    :header: include or omit header
+    """
     csvFile = io.StringIO()
     writer = csv.writer(csvFile)
     if header:
@@ -269,7 +279,7 @@ def export_tracks_as_csv(
                                     f"(kp) {geoJSONFeature.properties['key']} {round(coordinates[0])} {round(coordinates[1])}"
                                 )
                             # TODO: support for multiple GeoJSON Objects of the same type once the CSV supports it
-                    print(columns)
+
                     writer.writerow(columns)
                     yield csvFile.getvalue()
                     csvFile.seek(0)


### PR DESCRIPTION
fixes #449 
fixes #450

* These timestamps are fake, derived from the annotation FPS and frame number of the annotation.
* As such, they may do more harm than good. 