### PR TITLE
change getTrack

### DIFF
--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -44,9 +44,6 @@ type TrackMapType = Readonly<Map<TrackId, Track>>;
 const TracksSymbol = Symbol('tracks');
 type TracksType = Readonly<Ref<readonly Track[]>>;
 
-const GetTrackSymbol = Symbol('GetTrack');
-type GetTrackType = (trackId: number) => Track | undefined;
-
 const TypeStylingSymbol = Symbol('typeStyling');
 type TypeStylingType = Readonly<Ref<TypeStyling>>;
 
@@ -170,7 +167,6 @@ export interface State {
   intervalTree: IntervalTreeType;
   trackMap: TrackMapType;
   tracks: TracksType;
-  getTrack: GetTrackType;
   typeStyling: TypeStylingType;
   selectedKey: SelectedKeyType;
   selectedTrackId: SelectedTrackIdType;
@@ -200,7 +196,6 @@ function dummyState(): State {
     intervalTree: new IntervalTree(),
     trackMap: new Map<TrackId, Track>(),
     tracks: ref([]),
-    getTrack: () => undefined,
     typeStyling: ref({
       color() { return style.color; },
       strokeWidth() { return style.strokeWidth; },
@@ -237,7 +232,6 @@ function provideAnnotator(state: State, handler: Handler) {
   provide(IntervalTreeSymbol, state.intervalTree);
   provide(TrackMapSymbol, state.trackMap);
   provide(TracksSymbol, state.tracks);
-  provide(GetTrackSymbol, state.getTrack);
   provide(TypeStylingSymbol, state.typeStyling);
   provide(SelectedKeySymbol, state.selectedKey);
   provide(SelectedTrackIdSymbol, state.selectedTrackId);
@@ -301,10 +295,6 @@ function useTracks() {
   return use<TracksType>(TracksSymbol);
 }
 
-function useGetTrack() {
-  return use<GetTrackType>(GetTrackSymbol);
-}
-
 function useTypeStyling() {
   return use<TypeStylingType>(TypeStylingSymbol);
 }
@@ -341,7 +331,6 @@ export {
   useFrame,
   useTrackMap,
   useTracks,
-  useGetTrack,
   useTypeStyling,
   useSelectedKey,
   useSelectedTrackId,

--- a/client/src/use/useTrackStore.spec.ts
+++ b/client/src/use/useTrackStore.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 import Vue from 'vue';
 import CompositionApi, { watchEffect } from '@vue/composition-api';
-import useTrackStore from './useTrackStore';
+import useTrackStore, { getTrack } from './useTrackStore';
 
 Vue.use(CompositionApi);
 
@@ -50,9 +50,9 @@ describe('useTrackStore', () => {
   it('throws an error when you access a track that is missing', () => {
     const markChangesPending = () => null;
     const ts = useTrackStore({ markChangesPending });
-    expect(() => ts.getTrack(0)).toThrow('TrackId 0 not found in trackMap.');
+    expect(() => getTrack(ts.trackMap, 0)).toThrow('TrackId 0 not found in trackMap.');
     ts.addTrack(1000, 'foo');
-    expect(ts.getTrack(0)).toBeTruthy();
+    expect(getTrack(ts.trackMap, 0)).toBeTruthy();
   });
 
   it('updates a reactive list when member tracks change', async () => {

--- a/client/viame-web-common/components/AttributesSubsection.vue
+++ b/client/viame-web-common/components/AttributesSubsection.vue
@@ -9,8 +9,9 @@ import { Attribute } from 'viame-web-common/apispec';
 import {
   useSelectedTrackId,
   useFrame,
-  useGetTrack,
+  useTrackMap,
 } from 'vue-media-annotator/provides';
+import { getTrack } from 'vue-media-annotator/use/useTrackStore';
 import AttributeInput from 'viame-web-common/components/AttributeInput.vue';
 import PanelSubsection from 'viame-web-common/components/PanelSubsection.vue';
 
@@ -37,12 +38,12 @@ export default defineComponent({
   setup(props, { emit }) {
     const frameRef = useFrame();
     const selectedTrackIdRef = useSelectedTrackId();
-    const getTrack = useGetTrack();
+    const trackMap = useTrackMap();
     const activeSettings = ref(false);
 
     const selectedTrack = computed(() => {
       if (selectedTrackIdRef.value !== null) {
-        return getTrack(selectedTrackIdRef.value);
+        return getTrack(trackMap, selectedTrackIdRef.value);
       }
       return null;
     });
@@ -79,7 +80,7 @@ export default defineComponent({
 
     function updateAttribute({ name, value }: { name: string; value: unknown }) {
       if (selectedTrackIdRef.value) {
-        const track = getTrack(selectedTrackIdRef.value);
+        const track = getTrack(trackMap, selectedTrackIdRef.value);
         if (track !== undefined) {
           if (props.mode === 'Track') {
             track.setAttribute(name, value);

--- a/client/viame-web-common/components/TrackDetailsPanel.vue
+++ b/client/viame-web-common/components/TrackDetailsPanel.vue
@@ -14,8 +14,9 @@ import {
   useTypeStyling,
   useAllTypes,
   useHandler,
-  useGetTrack,
+  useTrackMap,
 } from 'vue-media-annotator/provides';
+import { getTrack } from 'vue-media-annotator/use/useTrackStore';
 import TrackItem from 'vue-media-annotator/components/TrackItem.vue';
 
 import { useApi, Attribute } from 'viame-web-common/apispec';
@@ -52,10 +53,10 @@ export default defineComponent({
     const attributes = ref([] as Attribute[]);
     const editingAttribute: Ref<Attribute | null> = ref(null);
     const editingError: Ref<string | null> = ref(null);
-    const getTrack = useGetTrack();
     const editingModeRef = useEditingMode();
     const typeStylingRef = useTypeStyling();
     const allTypesRef = useAllTypes();
+    const trackMap = useTrackMap();
     const { trackSelectNext, trackSplit, removeTrack } = useHandler();
 
     //Edit/Set single value by clicking
@@ -67,7 +68,7 @@ export default defineComponent({
     const { getAttributes, setAttribute, deleteAttribute } = useApi();
     const selectedTrack = computed(() => {
       if (selectedTrackIdRef.value !== null) {
-        return getTrack(selectedTrackIdRef.value);
+        return getTrack(trackMap, selectedTrackIdRef.value);
       }
       return null;
     });

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -13,6 +13,7 @@ import {
   useTrackStore,
   useEventChart,
 } from 'vue-media-annotator/use';
+import { getTrack } from 'vue-media-annotator/use/useTrackStore';
 import { provideAnnotator } from 'vue-media-annotator/provides';
 import {
   ImageAnnotator,
@@ -126,7 +127,6 @@ export default defineComponent({
       intervalTree,
       addTrack,
       insertTrack,
-      getTrack,
       removeTrack,
       getNewTrackId,
       removeTrack: tsRemoveTrack,
@@ -210,7 +210,6 @@ export default defineComponent({
       playbackComponent,
       newTrackSettings: clientSettings.newTrackSettings.value,
       selectTrack,
-      getTrack,
       selectNextTrack,
       addTrack,
       removeTrack,
@@ -218,7 +217,7 @@ export default defineComponent({
 
     async function trackSplit(trackId: TrackId | null, _frame: number) {
       if (typeof trackId === 'number') {
-        const track = getTrack(trackId);
+        const track = getTrack(trackMap, trackId);
         let newtracks: [Track, Track];
         try {
           newtracks = track.split(_frame, getNewTrackId(), getNewTrackId() + 1);
@@ -319,7 +318,6 @@ export default defineComponent({
         intervalTree,
         trackMap,
         tracks: filteredTracks,
-        getTrack,
         typeStyling,
         selectedKey,
         selectedTrackId,

--- a/client/viame-web-common/use/useModeManager.ts
+++ b/client/viame-web-common/use/useModeManager.ts
@@ -3,6 +3,7 @@ import {
 } from '@vue/composition-api';
 import { uniq, flatMapDeep } from 'lodash';
 import Track, { TrackId } from 'vue-media-annotator/track';
+import { getTrack } from 'vue-media-annotator/use/useTrackStore';
 import { RectBounds, updateBounds } from 'vue-media-annotator/utils';
 import { EditAnnotationTypes, VisibleAnnotationTypes } from 'vue-media-annotator/layers';
 
@@ -38,7 +39,6 @@ export default function useModeManager({
   newTrackSettings,
   recipes,
   selectTrack,
-  getTrack,
   selectNextTrack,
   addTrack,
   removeTrack,
@@ -51,7 +51,6 @@ export default function useModeManager({
   newTrackSettings: NewTrackSettings;
   recipes: Recipe[];
   selectTrack: (trackId: TrackId | null, edit: boolean) => void;
-  getTrack: (trackId: TrackId) => Track;
   selectNextTrack: (delta?: number) => TrackId | null;
   addTrack: (frame: number, defaultType: string) => Track;
   removeTrack: (trackId: TrackId) => void;
@@ -148,7 +147,7 @@ export default function useModeManager({
 
   function handleTrackTypeChange(trackId: TrackId | null, value: string) {
     if (trackId !== null) {
-      getTrack(trackId).setType(value);
+      getTrack(trackMap, trackId).setType(value);
     }
   }
 
@@ -359,13 +358,13 @@ export default function useModeManager({
 
   /** Toggle editing mode for track */
   function handleTrackEdit(trackId: TrackId) {
-    const track = getTrack(trackId);
+    const track = getTrack(trackMap, trackId);
     seekNearest(track);
     selectTrack(trackId, trackId === selectedTrackId.value ? (!editingTrack.value) : true);
   }
 
   function handleTrackClick(trackId: TrackId) {
-    const track = getTrack(trackId);
+    const track = getTrack(trackMap, trackId);
     seekNearest(track);
     selectTrack(trackId, editingTrack.value);
   }
@@ -374,7 +373,7 @@ export default function useModeManager({
     const newTrack = selectNextTrack(delta);
     if (newTrack !== null) {
       selectTrack(newTrack, false);
-      seekNearest(getTrack(newTrack));
+      seekNearest(getTrack(trackMap, newTrack));
     }
   }
 


### PR DESCRIPTION
I didn't mean for you to add `getTrack` to the provided interface.  I don't know if you did that because you wanted to or you thought it's what I wanted.

* This would be a departure from the style of provided state.  In your change, getTrack is a partial function application where trackMap is already in the closure.  We don't have any other state like that, so it might be good to do it this way just for consistency.  
* More importantly, though, the point of `getTrack` is to to throw an error if the requested track is missing, which is useful in the common case where missing track would need to be a runtime error (i.e. selectedTrackId should always be in TrackMap).  This is how it worked in your change, but the type of `GetTrackType` included `undefined` which somewhat defeated the purpose.
* If you want a getter that just returns undefined if missing, you don't need a new function.  `trackMap.get(key)` already has this method signature.

 