### PR TITLE
Small fix

### DIFF
--- a/client/viame-web-common/components/AttributeInput.vue
+++ b/client/viame-web-common/components/AttributeInput.vue
@@ -73,8 +73,9 @@ export default defineComponent({
     function change(event: InputEvent): void {
       const target = event.target as HTMLInputElement;
       const { name } = props;
-      if (target && target.value) {
-        emit('change', { name, value: target.value.trim() });
+      const value = target.value.trim();
+      if (value) {
+        emit('change', { name, value });
       } else {
         emit('change', { name, value: undefined });
       }


### PR DESCRIPTION
Removed the check for `target` because I couldn't see a valid execution path where that would ever be false.

If it's undefined or null, that should be a runtime error, right?