### PR TITLE
Updating clamping for zooming

### DIFF
--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -51,8 +51,12 @@ export default function useMediaController({ emit }: {
   }
 
   function resetZoom() {
-    geoViewerRef.value.zoom(geoViewerRef.value.zoomRange().origMin);
-    geoViewerRef.value.center({ x: 0, y: 0 });
+    const zoomAndCenter = geoViewerRef.value.zoomAndCenterFromBounds(
+      geoViewerRef.value.maxBounds(), 0,
+    );
+    geoViewerRef.value.zoom(zoomAndCenter.zoom);
+
+    geoViewerRef.value.center(zoomAndCenter.center);
   }
 
   function resetMapDimensions(width: number, height: number) {
@@ -75,8 +79,11 @@ export default function useMediaController({ emit }: {
       // do not set a "zoom out" limit so that 1x(map size) is always min.
       min: -Infinity,
       // 4x zoom max
-      max: 4,
+      max: Infinity,
     });
+    geoViewerRef.value.clampBoundsX(false);
+    geoViewerRef.value.clampBoundsY(false);
+    geoViewerRef.value.clampZoom(false);
     resetZoom();
   }
 


### PR DESCRIPTION
Issue #491 was modified slightly after your original fix.  

I think to satisfy the requirements you need to remove the clamping feature from the map in all dimensions.  This  allows the user to pan and scroll in/out as much as they want.  The main difference is that centering now requires calculating the actual center and zoom range, before we relied on clamping to auto center the image.

I need to do a bit more testing with video and multi sized images but I think this gives the max amount of freedom while still allows the user to reset the image.

Feel free to reject and just take some knowledge from this PR instead of merging.