### PR TITLE
Video Pipeline/Training Support

### DIFF
--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -219,6 +219,8 @@ def export_tracks_as_csv(
         metadata = None
         if fps is not None:
             metadata = {"fps": fps}
+            # TODO: REMOVE THIS RESET ONCE FIXED IN THE MAIN CONTAINER
+            # It is only here to enable training to work on videos because of a timestamp issue
             fps = None
         writeHeader(writer, metadata=metadata)
     for t in track_dict.values():

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -216,9 +216,9 @@ def export_tracks_as_csv(
     csvFile = io.StringIO()
     writer = csv.writer(csvFile)
     if header:
-        metadata = None
+        metadata = {}
         if fps is not None:
-            metadata = {"fps": fps}
+            metadata["fps"] = fps
             # TODO: REMOVE THIS RESET ONCE FIXED IN THE MAIN CONTAINER
             # It is only here to enable training to work on videos because of a timestamp issue
             fps = None

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -10,7 +10,7 @@ from typing import Dict, Generator, List, Tuple, Union
 from viame_server.serializers.models import Feature, Track, interpolate
 
 
-def writeHeader(writer: '_csv._writer'):
+def writeHeader(writer: '_csv._writer', metadata: Dict = None):
     writer.writerow(
         [
             "# 1: Detection or Track-id",
@@ -26,6 +26,12 @@ def writeHeader(writer: '_csv._writer'):
             "Confidence Pairs or Attributes",
         ]
     )
+    if metadata is not None:
+        metadata_list = []
+        for (key, value) in metadata.items():
+            metadata_list.append(f" {key}: {value}")
+        metadata_str = ",".join(metadata_list)
+        writer.writerow([f'# metadata -{metadata_str}'])
 
     writer.writerow(
         [f'# Written on {datetime.datetime.now().ctime()} by: viame_web_csv_writer']
@@ -210,7 +216,11 @@ def export_tracks_as_csv(
     csvFile = io.StringIO()
     writer = csv.writer(csvFile)
     if header:
-        writeHeader(writer)
+        metadata = None
+        if fps is not None:
+            metadata = {"fps": fps}
+            fps = None
+        writeHeader(writer, metadata=metadata)
     for t in track_dict.values():
         track = Track(**t)
         if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -218,9 +218,6 @@ def export_tracks_as_csv(
         metadata = {}
         if fps is not None:
             metadata["fps"] = fps
-            # TODO: REMOVE THIS RESET ONCE FIXED IN THE MAIN CONTAINER
-            # It is only here to enable training to work on videos because of a timestamp issue
-            fps = None
         writeHeader(writer, metadata)
     for t in track_dict.values():
         track = Track(**t)

--- a/server/viame_server/serializers/viame.py
+++ b/server/viame_server/serializers/viame.py
@@ -10,7 +10,7 @@ from typing import Dict, Generator, List, Tuple, Union
 from viame_server.serializers.models import Feature, Track, interpolate
 
 
-def writeHeader(writer: '_csv._writer', metadata: Dict = None):
+def writeHeader(writer: '_csv._writer', metadata: Dict):
     writer.writerow(
         [
             "# 1: Detection or Track-id",
@@ -26,12 +26,11 @@ def writeHeader(writer: '_csv._writer', metadata: Dict = None):
             "Confidence Pairs or Attributes",
         ]
     )
-    if metadata is not None:
-        metadata_list = []
-        for (key, value) in metadata.items():
-            metadata_list.append(f" {key}: {value}")
-        metadata_str = ",".join(metadata_list)
-        writer.writerow([f'# metadata -{metadata_str}'])
+    metadata_list = []
+    for (key, value) in metadata.items():
+        metadata_list.append(f" {key}: {value}")
+    metadata_str = ",".join(metadata_list)
+    writer.writerow([f'# metadata -{metadata_str}'])
 
     writer.writerow(
         [f'# Written on {datetime.datetime.now().ctime()} by: viame_web_csv_writer']
@@ -222,7 +221,7 @@ def export_tracks_as_csv(
             # TODO: REMOVE THIS RESET ONCE FIXED IN THE MAIN CONTAINER
             # It is only here to enable training to work on videos because of a timestamp issue
             fps = None
-        writeHeader(writer, metadata=metadata)
+        writeHeader(writer, metadata)
     for t in track_dict.values():
         track = Track(**t)
         if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):

--- a/server/viame_server/viame.py
+++ b/server/viame_server/viame.py
@@ -263,6 +263,7 @@ class Viame(Resource):
                     path=GetPathFromItemId(str(item["_id"])),
                     folderId=str(item["folderId"]),
                     auxiliaryFolderId=auxiliary["_id"],
+                    itemId=str(item["_id"]),
                     girder_job_title=(
                         "Converting {} to a web friendly format".format(
                             str(item["_id"])

--- a/server/viame_server/viame_detection.py
+++ b/server/viame_server/viame_detection.py
@@ -46,6 +46,7 @@ class ViameDetection(Resource):
             {
                 'folderId': folder['_id'],
                 'meta.codec': 'h264',
+                'meta.source_video': {'$exists': False},
             }
         )
         if item:

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -95,8 +95,6 @@ def run_pipeline(self: Task, params: PipelineJob):
 
     if input_type == 'video':
         # filter files for source video file
-        # TODO: Update this to  use validVideoTypes or prefilter before tasks.py and provide
-        # a list of media Ids for download instead of the recursive folder
         input_file = get_source_video(input_path, input_folder, self.girder_client)
         # Preserving default behavior incase new stuff fails
         if input_file is None:

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -13,9 +13,9 @@ from girder_worker.utils import JobManager, JobStatus
 from GPUtil import getGPUs
 
 from viame_tasks.utils import (
+    get_source_video,
     organize_folder_for_training,
     read_and_close_process_outputs,
-    get_source_video,
 )
 from viame_utils.types import PipelineJob
 

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -416,7 +416,13 @@ def convert_video(self: Task, path, folderId, auxiliaryFolderId, itemId):
         manager.updateStatus(JobStatus.PUSHING_OUTPUT)
         new_file = gc.uploadFileToFolder(folderId, output_path)
         gc.addMetadataToItem(new_file['itemId'], {"codec": "h264"})
-        gc.addMetadataToItem(itemId, {"source_video": True})
+        gc.addMetadataToItem(
+            itemId,
+            {
+                "source_video": True,
+                "codec": videostream[0]["codec_name"],
+            },
+        )
         gc.addMetadataToFolder(
             folderId,
             {

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -74,6 +74,7 @@ def run_pipeline(self: Task, params: PipelineJob):
         is_directory = os.path.isdir(full_file_path)
         if (not is_directory) and (
             not os.path.splitext(file_name)[1].lower() == '.csv'
+            and (not os.path.splitext(file_name)[1].lower() == '.json')
         ):
             filtered_directory_files.append(file_name)
 
@@ -92,7 +93,19 @@ def run_pipeline(self: Task, params: PipelineJob):
     pipeline_path = pipeline_path.replace(" ", r"\ ")
 
     if input_type == 'video':
+        # Preserving default behavior incase new stuff fails
         input_file = os.path.join(input_path, filtered_directory_files[0])
+        # filter files for source video file
+        # TODO: Update this to  use validVideoTypes or prefilter before tasks.py and provide
+        # a list of mediate Ids for download instead of the recursive folder (could get in trouble with that)
+        folder_contents = self.girder_client.listItem(input_folder)
+        for item in folder_contents:
+            file_name = os.path.join(input_path, item.get("name"))
+            if item.get("meta", {}).get("codec") is None and (
+                not os.path.splitext(file_name)[1].lower() == '.json'
+                and (not os.path.splitext(file_name)[1].lower() == '.csv')
+            ):
+                input_file = file_name
         command = [
             f"cd {conf.viame_install_path} &&",
             ". ./setup_viame.sh &&",

--- a/server/viame_tasks/tasks.py
+++ b/server/viame_tasks/tasks.py
@@ -96,7 +96,7 @@ def run_pipeline(self: Task, params: PipelineJob):
     if input_type == 'video':
         # filter files for source video file
         # TODO: Update this to  use validVideoTypes or prefilter before tasks.py and provide
-        # a list of media Ids for download instead of the recursive folder (could get in trouble with that)
+        # a list of media Ids for download instead of the recursive folder
         input_file = get_source_video(input_path, input_folder, self.girder_client)
         # Preserving default behavior incase new stuff fails
         if input_file is None:
@@ -249,7 +249,7 @@ def train_pipeline(
             groundtruth_file = organize_folder_for_training(
                 root_data_dir, download_path, groundtruth_path
             )
-            # We point to file if video
+            # We point to file if is a video
             if source_folder.get("meta", {}).get("type") == "video":
                 video_file = get_source_video(download_path, source_folder["_id"], gc)
                 if video_file is not None:
@@ -284,6 +284,8 @@ def train_pipeline(
             process_log_file = tempfile.TemporaryFile()
             process_err_file = tempfile.TemporaryFile()
             manager.updateStatus(JobStatus.RUNNING)
+            cmd = " ".join(command)
+            print('Running command:', cmd)
             # Call viame_train_detector
             process = Popen(
                 " ".join(command),

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -7,6 +7,9 @@ from typing import IO, Optional, Tuple
 
 from girder_worker.task import Task
 
+# TODO: Move viame_server.constants into a shared area like viame_utils to share constants
+validVideoFormats = [".mp4", ".avi", ".mov", ".mpg"]
+
 
 def read_and_close_process_outputs(
     process: Popen,
@@ -71,7 +74,6 @@ def organize_folder_for_training(
 
 
 def get_source_video(input_path: Path, folderId: str, girder_client):
-    validVideoFormats = [".mp4", ".avi", ".mov", ".mpg"]
     folder_contents = girder_client.listItem(folderId)
     for item in folder_contents:
         file_name = os.path.join(input_path, item.get("name"))

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from pathlib import Path
 from subprocess import Popen, TimeoutExpired

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -1,4 +1,6 @@
 import shutil
+import os
+
 from pathlib import Path
 from subprocess import Popen, TimeoutExpired
 from tempfile import mktemp
@@ -67,3 +69,15 @@ def organize_folder_for_training(
     shutil.move(str(downloaded_groundtruth), groundtruth)
 
     return groundtruth
+
+
+def get_source_video(input_path: Path, folderId: str, girder_client):
+    validVideoFormats = [".mp4", ".avi", ".mov", ".mpg"]
+    folder_contents = girder_client.listItem(folderId)
+    for item in folder_contents:
+        file_name = os.path.join(input_path, item.get("name"))
+        extension = os.path.splitext(file_name)[1].lower()
+        print(extension)
+        if item.get("meta", {}).get("codec") is None and extension in validVideoFormats:
+            return file_name
+    return None

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -5,10 +5,8 @@ from subprocess import Popen, TimeoutExpired
 from tempfile import mktemp
 from typing import IO, Optional, Tuple
 
+from girder_client import GirderClient
 from girder_worker.task import Task
-
-# TODO: Move viame_server.constants into a shared area like viame_utils to share constants
-validVideoFormats = [".mp4", ".avi", ".mov", ".mpg"]
 
 
 def read_and_close_process_outputs(
@@ -73,11 +71,24 @@ def organize_folder_for_training(
     return groundtruth
 
 
-def get_source_video(input_path: Path, folderId: str, girder_client):
+def get_source_video_filename(folderId: str, girder_client: GirderClient):
+    """
+    Searches a folderId for source videos that are compatible with training/pipelines
+    Will look for {"source_video":True} metadata first, then fall back to the converted video
+    indicated by  {"codec":"h264"}
+    If neither found it will return None
+
+    :folderId: Current path to wehere the items sit
+
+    :girder_client: girder_client used to request the data
+    """
+
     folder_contents = girder_client.listItem(folderId)
+    backup_converted_file = None
     for item in folder_contents:
-        file_name = os.path.join(input_path, item.get("name"))
-        extension = os.path.splitext(file_name)[1].lower()
-        if item.get("meta", {}).get("codec") is None and extension in validVideoFormats:
+        file_name = item.get("name")
+        if item.get("meta", {}).get("source_video") is True:
             return file_name
-    return None
+        if item.get("meta", {}).get("codec") == "h264":
+            backup_converted_file = file_name
+    return backup_converted_file

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -76,7 +76,6 @@ def get_source_video(input_path: Path, folderId: str, girder_client):
     for item in folder_contents:
         file_name = os.path.join(input_path, item.get("name"))
         extension = os.path.splitext(file_name)[1].lower()
-        print(extension)
         if item.get("meta", {}).get("codec") is None and extension in validVideoFormats:
             return file_name
     return None

--- a/server/viame_tasks/utils.py
+++ b/server/viame_tasks/utils.py
@@ -1,6 +1,5 @@
-import shutil
 import os
-
+import shutil
 from pathlib import Path
 from subprocess import Popen, TimeoutExpired
 from tempfile import mktemp


### PR DESCRIPTION
Not the best way to solve the issue but the least intrusive way for the time being.

Pipeline Running Updates:

- `image-sequence` for training will now filter out .json files
- `video` type will now load the folder filter out any non compatible video files and then look for the video file which doesn't have the codec meta tag on it.  I would like to share the `validMediaFiles` with the constants folder or maybe do this filtering before calling the task, I just didn't want to go with too big of a change right now with just getting video training to work.

CSV Metadata Update:

- Added in the writing of the metadata to the header.  Right not it only writes the fps value for the training and other items to user.  More stuff can be added in the future, just trying to keep it fairly simple right now.
- **NOTE!!!!** - The resetting of `fps = None` is there because of a training bug right now.  Once fixed that will be removed.

Training Updates:
- In the beginning of the training I updated the CSV creation to be more like export and include stuff like the `fps` so it knows to write it.
- Training will use the same function to find the source video file and place that in the training manifest file.  This means the file is directly referenced with the included extensions as well.

