### PR TITLE
Add current frame image filename to display for image-sequence

### DIFF
--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -60,90 +60,81 @@ export default defineComponent({
       { bind: 'd', handler: mediaController.prevFrame, disabled: $prompt.visible() },
     ]"
   >
-    <v-toolbar
-      height="80px"
-      flat
-    >
-      <v-container
-        fluid
-        class="pa-0"
-      >
-        <v-row>
-          <v-slider
-            hide-details
-            :min="0"
-            :max="mediaController.maxFrame.value"
-            :value="data.frame"
-            @start="dragHandler.start"
-            @end="dragHandler.end"
-            @input="input"
+    <v-card class="px-4 py-1">
+      <v-slider
+        hide-details
+        :min="0"
+        :max="mediaController.maxFrame.value"
+        :value="data.frame"
+        @start="dragHandler.start"
+        @end="dragHandler.end"
+        @input="input"
+      />
+      <v-row no-gutters>
+        <v-col class="pl-1 py-1 shrink">
+          <slot
+            justify="start"
+            name="timelineControls"
           />
-        </v-row>
-        <v-row
-          align-content="space-between"
-          dense
+        </v-col>
+        <v-col
+          class="py-1 shrink"
+          style="min-width: 100px;"
         >
-          <v-col class="pl-1 py-1">
-            <slot
-              justify="start"
-              name="timelineControls"
-            />
-          </v-col>
-          <v-col
-            align="center"
-            class="py-1 shrink"
-            style="min-width: 100px;"
+          <v-btn
+            icon
+            small
+            title="(d, left-arrow) previous frame"
+            @click="mediaController.prevFrame"
           >
-            <v-btn
-              icon
-              small
-              title="(d, left-arrow) previous frame"
-              @click="mediaController.prevFrame"
-            >
-              <v-icon>mdi-skip-previous</v-icon>
-            </v-btn>
-            <v-btn
-              v-if="!mediaController.playing.value"
-              icon
-              small
-              title="(space) Play"
-              @click="mediaController.play"
-            >
-              <v-icon>mdi-play</v-icon>
-            </v-btn>
-            <v-btn
-              v-else
-              icon
-              small
-              title="(space) Pause"
-              @click="mediaController.pause"
-            >
-              <v-icon>mdi-pause</v-icon>
-            </v-btn>
-            <v-btn
-              icon
-              small
-              title="(f, right-arrow) next frame"
-              @click="mediaController.nextFrame"
-            >
-              <v-icon>mdi-skip-next</v-icon>
-            </v-btn>
-          </v-col>
-          <v-col
-            class="pl-1 py-1"
-            align="right"
+            <v-icon>mdi-skip-previous</v-icon>
+          </v-btn>
+          <v-btn
+            v-if="!mediaController.playing.value"
+            icon
+            small
+            title="(space) Play"
+            @click="mediaController.play"
           >
-            <v-btn
-              icon
-              small
-              title="(r)eset pan and zoom"
-              @click="mediaController.resetZoom"
-            >
-              <v-icon>mdi-image-filter-center-focus</v-icon>
-            </v-btn>
-          </v-col>
-        </v-row>
-      </v-container>
-    </v-toolbar>
+            <v-icon>mdi-play</v-icon>
+          </v-btn>
+          <v-btn
+            v-else
+            icon
+            small
+            title="(space) Pause"
+            @click="mediaController.pause"
+          >
+            <v-icon>mdi-pause</v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            small
+            title="(f, right-arrow) next frame"
+            @click="mediaController.nextFrame"
+          >
+            <v-icon>mdi-skip-next</v-icon>
+          </v-btn>
+        </v-col>
+        <v-col
+          class="pl-1 py-1 shrink"
+        >
+          <slot name="middle" />
+        </v-col>
+        <v-col
+          class="pl-1 py-1"
+          align="right"
+        >
+          <v-btn
+            icon
+            small
+            title="(r)eset pan and zoom"
+            @click="mediaController.resetZoom"
+          >
+            <v-icon>mdi-image-filter-center-focus</v-icon>
+          </v-btn>
+        </v-col>
+      </v-row>
+    </v-card>
   </div>
 </template>

--- a/client/viame-web-common/components/ControlsContainer.vue
+++ b/client/viame-web-common/components/ControlsContainer.vue
@@ -2,6 +2,9 @@
 import {
   defineComponent, ref, PropType,
 } from '@vue/composition-api';
+import type { DatasetType } from 'viame-web-common/apispec';
+import type { ImageDataItem } from 'vue-media-annotator/components/annotators/ImageAnnotator.vue';
+
 import {
   Controls,
   EventChart,
@@ -28,6 +31,14 @@ export default defineComponent({
       type: Object as PropType<unknown>,
       required: true,
     },
+    datasetType: {
+      type: String as PropType<DatasetType>,
+      required: true,
+    },
+    imageData: {
+      type: Array as PropType<ImageDataItem[]>,
+      default: () => [],
+    },
   },
 
   setup() {
@@ -53,52 +64,61 @@ export default defineComponent({
 
 <template>
   <div>
-    <Controls>
-      <template slot="timelineControls">
-        <div style="min-width: 210px">
-          <v-tooltip
-            open-delay="200"
-            bottom
-          >
-            <template #activator="{ on }">
-              <v-icon
-                small
-                v-on="on"
-                @click="collapsed=!collapsed"
-              >
-                {{ collapsed?'mdi-chevron-up-box': 'mdi-chevron-down-box' }}
-              </v-icon>
-            </template>
-            <span>Collapse/Expand Timeline</span>
-          </v-tooltip>
-          <v-btn
-            class="ml-2"
-            :class="{'timeline-button':currentView!=='Detections' || collapsed}"
-            depressed
-            :outlined="currentView==='Detections' && !collapsed"
-            x-small
-            tab-index="-1"
-            @click="toggleView('Detections')"
-          >
-            Detections
-          </v-btn>
-          <v-btn
-            class="ml-2"
-            :class="{'timeline-button':currentView!=='Events' || collapsed}"
-            depressed
-            :outlined="currentView==='Events' && !collapsed"
-            x-small
-            tab-index="-1"
-            @click="toggleView('Events')"
-          >
-            Events
-          </v-btn>
-        </div>
-      </template>
-    </Controls>
-    <timeline-wrapper v-if="(!collapsed)">
+    <timeline-wrapper>
       <template #default="{ maxFrame, frame, seek }">
+        <Controls>
+          <template slot="timelineControls">
+            <div style="min-width: 210px">
+              <v-tooltip
+                open-delay="200"
+                bottom
+              >
+                <template #activator="{ on }">
+                  <v-icon
+                    small
+                    v-on="on"
+                    @click="collapsed=!collapsed"
+                  >
+                    {{ collapsed?'mdi-chevron-up-box': 'mdi-chevron-down-box' }}
+                  </v-icon>
+                </template>
+                <span>Collapse/Expand Timeline</span>
+              </v-tooltip>
+              <v-btn
+                class="ml-2"
+                :class="{'timeline-button':currentView!=='Detections' || collapsed}"
+                depressed
+                :outlined="currentView==='Detections' && !collapsed"
+                x-small
+                tab-index="-1"
+                @click="toggleView('Detections')"
+              >
+                Detections
+              </v-btn>
+              <v-btn
+                class="ml-2"
+                :class="{'timeline-button':currentView!=='Events' || collapsed}"
+                depressed
+                :outlined="currentView==='Events' && !collapsed"
+                x-small
+                tab-index="-1"
+                @click="toggleView('Events')"
+              >
+                Events
+              </v-btn>
+            </div>
+          </template>
+          <template #middle>
+            <span
+              v-if="datasetType === 'image-sequence'"
+              class="text-middle px-3"
+            >
+              {{ imageData[frame].filename }}
+            </span>
+          </template>
+        </Controls>
         <Timeline
+          v-if="(!collapsed)"
           :max-frame="maxFrame"
           :frame="frame"
           :display="!collapsed"
@@ -142,7 +162,15 @@ export default defineComponent({
 </template>
 
 <style lang="scss" scoped>
+.text-middle {
+  vertical-align: baseline;
+  font-family: monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: bold;
+}
 .timeline-button {
-    border: thin solid transparent;
+  border: thin solid transparent;
 }
 </style>


### PR DESCRIPTION
This looks like a lot of changes, but it's really just a couple indentation changes.  I removed the `v-toolbar` and `v-container` wrappers in the toolbar because they provided no value, replaced with a fluid-height `v-card` so that text wrapping looked correct at narrow widths.

Had to move controls into the `timeline-wrapper` so that `frame` prop from annotator slot could be used.

Got rid of `annotatorType` derived property because we already have an explicit `meta.type` associated with the dataset.  

![Screenshot from 2020-12-23 09-35-53](https://user-images.githubusercontent.com/4214172/103008842-ba6f3200-4503-11eb-8463-668453c5a393.png)

# Location

I put it in the time control bar because that's where it made most sense to me.  It's tightly coupled to time/frame controls, so having it in the header seemed like a violation of locality.  Also, I haven't done this yet, but on videos the filename text would be replaced with a timestamp, and that's objectively the correct place to put a timestamp.

resolves #300
