### PR TITLE
Switch to EventSource for notifications

### DIFF
--- a/client/platform/web-girder/main.ts
+++ b/client/platform/web-girder/main.ts
@@ -33,7 +33,7 @@ SentryInit({
   release: process.env.VUE_APP_GIT_HASH,
 });
 
-const notificationBus = new NotificationBus(girderRest);
+const notificationBus = new NotificationBus(girderRest, { useEventSource: true });
 notificationBus.connect();
 
 girderRest.fetchUser().then(() => {


### PR DESCRIPTION
I tried it out and I haven't had any trouble with the events timing out.  There's really no reason to think they would unless there's a bug on Girder's side.