### PR TITLE
Better meta save logic

### DIFF
--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -3,7 +3,7 @@ import IntervalTree from '@flatten-js/interval-tree';
 import Track, { TrackId } from '../track';
 
 interface UseTrackStoreParams {
-  markChangesPending: (type: 'upsert' | 'delete', track?: Track) => void;
+  markChangesPending: (type: 'upsert' | 'delete', track: Track) => void;
 }
 
 export function getTrack(

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -118,13 +118,15 @@ export default defineComponent({
       new HeadTail(),
     ];
 
+    const markMetaChangesPending = () => markChangesPending('meta');
+
     const {
       typeStyling,
       stateStyling,
       updateTypeStyle,
       populateTypeStyles,
       getTypeStyles,
-    } = useStyling({ markChangesPending });
+    } = useStyling({ markChangesPending: markMetaChangesPending });
 
     const {
       trackMap,
@@ -153,7 +155,11 @@ export default defineComponent({
       deleteType,
       updateCheckedTypes,
       updateCheckedTrackId,
-    } = useTrackFilters({ sortedTracks, removeTrack, markChangesPending });
+    } = useTrackFilters({
+      sortedTracks,
+      removeTrack,
+      markChangesPending: markMetaChangesPending,
+    });
 
     const {
       selectedTrackId,
@@ -359,7 +365,6 @@ export default defineComponent({
       visibleModes,
       /* methods */
       handler: globalHandler,
-      markChangesPending,
       save,
       saveThreshold,
       updateNewTrackSettings,

--- a/client/viame-web-common/components/Viewer.vue
+++ b/client/viame-web-common/components/Viewer.vue
@@ -86,7 +86,7 @@ export default defineComponent({
     const datasetType: Ref<DatasetType> = ref('image-sequence');
     const videoUrl = ref(undefined as undefined | string);
     const frame = ref(0); // the currently displayed frame number
-    const { loadDetections, loadMetadata } = useApi();
+    const { loadDetections, loadMetadata, saveMetadata } = useApi();
     // Loaded flag prevents annotator window from populating
     // with stale data from props, for example if a persistent store
     // like vuex is used to drive them.
@@ -255,7 +255,7 @@ export default defineComponent({
     }
 
     function saveThreshold() {
-      saveToServer({
+      saveMetadata(props.datasetId, {
         confidenceFilters: confidenceFilters.value,
       });
     }


### PR DESCRIPTION
* Separate locks for meta and tracks
* Prove it works by allowing saveDetections and saveMetadat to execute in parallel, shortening time to perform save.
* Optimization to prevent calling saveMetadata in `useSave` if no metadata has changed
* Don't use useSave.save when updating threshold, just call api function directly.