### PR TITLE
windows support for training

### DIFF
--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -217,6 +217,7 @@ async function train(
     `--input-truth "${groundTruthFileList}"`,
     `--config "${configFilePath}"`,
     '--no-query',
+    '--no-adv-prints',
   ];
 
   const job = spawn(command.join(' '), {


### PR DESCRIPTION
Simple command line to enable support for training in windows by eliminating some incompatibility with logging.  It reduces advance displaying of the console commands.  I don't think this matters because we are using just standard txt for displaying and output on desktop. 

I tested on Linux and there were no adverse effects with adding this command line in here.

This was tested on windows using some modified python to fix an unrelated error that should be released soon (I would think v0.13.2). 

