### PR TITLE
Creation mode switching bugfix

### DIFF
--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -171,7 +171,8 @@ export default defineComponent({
           editingTracks.push(trackFrame);
         }
         if (editingTracks.length) {
-          if (editingTrack && !editAnnotationLayer.creationIncomplete()) {
+          if (editingTrack) {
+            editAnnotationLayer.checkCreationIncomplete(editingTrack, selectedKey);
             editAnnotationLayer.setType(editingTrack);
             editAnnotationLayer.setKey(selectedKey);
             editAnnotationLayer.changeData(editingTracks);

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -253,9 +253,13 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
    * Provides an indicator that the system is still waiting for creation
    * geoJSON data.  This is relevant which switching focus while in creation mode
    */
-  creationIncomplete(): boolean {
+  checkCreationIncomplete(editingType: EditAnnotationTypes, key: string) {
+    if (editingType !== this.type || key !== this.selectedKey) {
+      this.skipNextExternalUpdate = false;
+      return;
+    }
     const features = this.featureLayer.annotations();
-    return this.getMode() === 'creation'
+    this.skipNextExternalUpdate = this.getMode() === 'creation'
     && (!features.length || (features[0] && !features[0].coordinates().length));
   }
 


### PR DESCRIPTION
More explicitly determines what changes will cause disabling the current editing process.  Changes to the track type or other values shouldn't cause the in process annotation to disable and reset.   Changes to the editType, selectedTrack or selectedKey will cause the editAnnotationLayer to disable and switch to a different mode.

I'm using the existing changeData stuff for line creation to skip updates when data not relevant to the current editing Type (line,rectnagle, poly) or selectedKey isn't changed.  So if track types are changed it won't kick it out of editing mode.

I found another issue in here related to continuous head/tail mode that has to do with rectangleLayer selecting the previously created mode on mouse release right after creation causing the older trackId to be reselected instead of the new one.